### PR TITLE
macos: Use registry entry ID instead of location ID to identify device.

### DIFF
--- a/src/enumeration.rs
+++ b/src/enumeration.rs
@@ -39,6 +39,9 @@ pub struct DeviceInfo {
     pub(crate) interfaces: HashMap<u8, OsString>,
 
     #[cfg(target_os = "macos")]
+    pub(crate) registry_id: u64,
+
+    #[cfg(target_os = "macos")]
     pub(crate) location_id: u32,
 
     pub(crate) bus_number: u8,
@@ -94,6 +97,12 @@ impl DeviceInfo {
     #[cfg(target_os = "macos")]
     pub fn location_id(&self) -> u32 {
         self.location_id
+    }
+
+    /// *(macOS-only)* IOKit [Registry Entry ID](https://developer.apple.com/documentation/iokit/1514719-ioregistryentrygetregistryentryi?language=objc)
+    #[cfg(target_os = "macos")]
+    pub fn registry_entry_id(&self) -> u64 {
+        self.registry_id
     }
 
     /// Number identifying the bus / host controller where the device is connected.
@@ -207,6 +216,12 @@ impl std::fmt::Debug for DeviceInfo {
                 .field("port_number", &self.port_number)
                 .field("driver", &self.driver)
                 .field("interfaces", &self.interfaces);
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            s.field("location_id", &self.location_id);
+            s.field("registry_entry_id", &self.registry_id);
         }
 
         s.finish()

--- a/src/platform/macos_iokit/device.rs
+++ b/src/platform/macos_iokit/device.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 use super::{
-    enumeration::service_by_location_id,
+    enumeration::service_by_registry_id,
     events::EventRegistration,
     iokit::{call_iokit_function, check_iokit_return},
     iokit_usb::{EndpointInfo, IoKitDevice, IoKitInterface},
@@ -22,7 +22,8 @@ pub(crate) struct MacDevice {
 
 impl MacDevice {
     pub(crate) fn from_device_info(d: &DeviceInfo) -> Result<Arc<MacDevice>, Error> {
-        let service = service_by_location_id(d.location_id)?;
+        log::info!("Opening device from registry id {}", d.registry_id);
+        let service = service_by_registry_id(d.registry_id)?;
         let device = IoKitDevice::new(service)?;
         let _event_registration = add_event_source(device.create_async_event_source()?);
 


### PR DESCRIPTION
It changes when the device is disconnected and reconnected, while the location ID is like a port number.

This prevents opening the wrong device if you hold onto a `DeviceInfo` for a while and a different device is connected to the same port.