### PR TITLE
Move futures-lite to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ repository = "https://github.com/kevinmehall/nusb"
 
 [dependencies]
 atomic-waker = "1.1.2"
-futures-lite = "1.13.0"
 log = "0.4.20"
 once_cell = "1.18.0"
 slab = "0.4.9"
 
 [dev-dependencies]
 env_logger = "0.10.0"
+futures-lite = "1.13.0"
 
 [target.'cfg(target_os="linux")'.dependencies]
 rustix = { version = "0.38.17", features = ["fs", "event"] }


### PR DESCRIPTION
Hi, this an interesting library!

I noticed `futures-lite` is only used in `examples/` and (non-running) documentation tests. This change moves that dependency to `dev-dependencies` from `dependencies` since it's not used by the library itself. This means it's not added to the dependency tree of the `nusb`'s users.