### PR TITLE
MacOS: Reset the static eventloop if the worker thread terminates

### DIFF
--- a/src/platform/macos_iokit/events.rs
+++ b/src/platform/macos_iokit/events.rs
@@ -51,6 +51,11 @@ pub(crate) fn add_event_source(source: CFRunLoopSource) -> EventRegistration {
             runloop.add_source(&source.0, unsafe { kCFRunLoopCommonModes });
             tx.send(SendCFRunLoop(runloop)).unwrap();
             CFRunLoop::run_current();
+
+            // Remove the global if we exited the run loop
+            let mut el = EVENT_LOOP.lock().unwrap();
+            let _ = el.runloop.take();
+            el.count = 0;
             info!("event loop thread exited");
         });
         event_loop.runloop = Some(rx.recv().expect("failed to start run loop thread"));


### PR DESCRIPTION
Note that I have no idea what I am doing, but was hunting for static state, and found this.
It seems to address what I saw in #18, but should definitely be sanity checked.

It seems that it is possible for the worker thread to exit (likely because there are no devices
still attached), but for the static to *appear* to still be working, so when we go back to
having devices, there is no event loop to service them.

This PR resets the static to the initial state when the worker thread terminates.

Closes #18 