### PR TITLE
Make SysfsPath contents pub.

### DIFF
--- a/src/enumeration.rs
+++ b/src/enumeration.rs
@@ -62,9 +62,17 @@ pub struct DeviceInfo {
 
 impl DeviceInfo {
     /// *(Linux-only)* Sysfs path for the device.
+    #[doc(hidden)]
+    #[deprecated = "use `sysfs_path()` instead"]
     #[cfg(target_os = "linux")]
     pub fn path(&self) -> &SysfsPath {
         &self.path
+    }
+
+    /// *(Linux-only)* Sysfs path for the device.
+    #[cfg(target_os = "linux")]
+    pub fn sysfs_path(&self) -> &std::path::Path {
+        &self.path.0
     }
 
     /// *(Windows-only)* Instance ID path of this device

--- a/src/platform/linux_usbfs/enumeration.rs
+++ b/src/platform/linux_usbfs/enumeration.rs
@@ -11,7 +11,7 @@ use crate::Error;
 use crate::Speed;
 
 #[derive(Debug, Clone)]
-pub struct SysfsPath(PathBuf);
+pub struct SysfsPath(pub(crate) PathBuf);
 
 impl SysfsPath {
     pub(crate) fn read_attr<T: FromStr>(&self, attr: &str) -> Result<T, io::Error>


### PR DESCRIPTION
Currently you can get a SysfsPath from DeviceInfo, but you can't really do anything
with it because it has no methods and the inner PathBuf is private.

This makes it pub.

The SysfsPath type is a bit useless from outside the crate though. Alternatvely DeviceInfo.path() could return a PathBuf,  but that's a breaking change.
