### PR TITLE
Implement `detach_and_claim_interface`

### DIFF
--- a/examples/detach_claim.rs
+++ b/examples/detach_claim.rs
@@ -1,0 +1,14 @@
+//! Detach the kernel driver for an FTDI device and then reattach it.
+use std::{thread::sleep, time::Duration};
+fn main() {
+    env_logger::init();
+    let di = nusb::list_devices()
+        .unwrap()
+        .find(|d| d.vendor_id() == 0x0403 && d.product_id() == 0x6010)
+        .expect("device should be connected");
+
+    let device = di.open().unwrap();
+    let interface = device.detach_and_claim_interface(0).unwrap();
+    sleep(Duration::from_secs(1));
+    drop(interface);
+}

--- a/src/device.rs
+++ b/src/device.rs
@@ -52,6 +52,16 @@ impl Device {
         Ok(Interface { backend })
     }
 
+    /// Detach kernel drivers and open an interface of the device and claim it for exclusive use.
+    ///
+    /// ### Platform notes
+    /// This function can only detach kernel drivers on Linux. Calling on other platforms has
+    /// the same effect as [`claim_interface`][`Device::claim_interface`].
+    pub fn detach_and_claim_interface(&self, interface: u8) -> Result<Interface, Error> {
+        let backend = self.backend.detach_and_claim_interface(interface)?;
+        Ok(Interface { backend })
+    }
+
     /// Get information about the active configuration.
     ///
     /// This returns cached data and does not perform IO. However, it can fail if the

--- a/src/platform/linux_usbfs/device.rs
+++ b/src/platform/linux_usbfs/device.rs
@@ -230,6 +230,23 @@ impl LinuxDevice {
         Ok(Arc::new(LinuxInterface {
             device: self.clone(),
             interface,
+            reattach: false,
+        }))
+    }
+
+    pub(crate) fn detach_and_claim_interface(
+        self: &Arc<Self>,
+        interface: u8,
+    ) -> Result<Arc<LinuxInterface>, Error> {
+        usbfs::detach_and_claim_interface(&self.fd, interface)?;
+        debug!(
+            "Claimed interface {interface} on device id {dev}",
+            dev = self.events_id
+        );
+        Ok(Arc::new(LinuxInterface {
+            device: self.clone(),
+            interface,
+            reattach: true,
         }))
     }
 
@@ -272,6 +289,7 @@ impl Drop for LinuxDevice {
 pub(crate) struct LinuxInterface {
     pub(crate) interface: u8,
     pub(crate) device: Arc<LinuxDevice>,
+    pub(crate) reattach: bool,
 }
 
 impl LinuxInterface {
@@ -326,5 +344,13 @@ impl Drop for LinuxInterface {
             "Released interface {} on device {}: {res:?}",
             self.interface, self.device.events_id
         );
+
+        if res.is_ok() && self.reattach {
+            let res = usbfs::attach_kernel_driver(&self.device.fd, self.interface);
+            debug!(
+                "Reattached kernel drivers for interface {} on device {}: {res:?}",
+                self.interface, self.device.events_id
+            );
+        }
     }
 }

--- a/src/platform/linux_usbfs/device.rs
+++ b/src/platform/linux_usbfs/device.rs
@@ -246,7 +246,7 @@ impl LinuxDevice {
                 let driver = usbfs::get_driver(&self.fd, interface)?;
 
                 // avoid detaching another instance of nusb or libusb
-                if !driver.starts_with(b"usbfs\0") {
+                if driver.is_some_and(|d| !d.starts_with(b"usbfs\0")) {
                     usbfs::detach_kernel_driver(&self.fd, interface)?;
                 }
 

--- a/src/platform/linux_usbfs/usbfs.rs
+++ b/src/platform/linux_usbfs/usbfs.rs
@@ -78,7 +78,7 @@ pub fn get_driver<Fd: AsFd>(fd: Fd, interface: u8) -> io::Result<[u8; 256]> {
 
     unsafe {
         let ctl =
-            ioctl::Updater::<ioctl::ReadOpcode<b'U', 8, GetDriver>, GetDriver>::new(&mut driver);
+            ioctl::Updater::<ioctl::WriteOpcode<b'U', 8, GetDriver>, GetDriver>::new(&mut driver);
         ioctl::ioctl(&fd, ctl)?;
     }
 
@@ -100,7 +100,7 @@ pub fn detach_kernel_driver<Fd: AsFd>(fd: Fd, interface: u8) -> io::Result<()> {
             data: std::ptr::null_mut(),
         };
         let ctl =
-            ioctl::Setter::<ioctl::WriteOpcode<b'U', 18, UsbFsIoctl>, UsbFsIoctl>::new(command);
+            ioctl::Setter::<ioctl::ReadWriteOpcode<b'U', 18, UsbFsIoctl>, UsbFsIoctl>::new(command);
         ioctl::ioctl(fd, ctl)
     }
 }
@@ -113,7 +113,7 @@ pub fn attach_kernel_driver<Fd: AsFd>(fd: Fd, interface: u8) -> io::Result<()> {
             data: std::ptr::null_mut(),
         };
         let ctl =
-            ioctl::Setter::<ioctl::WriteOpcode<b'U', 18, UsbFsIoctl>, UsbFsIoctl>::new(command);
+            ioctl::Setter::<ioctl::ReadWriteOpcode<b'U', 18, UsbFsIoctl>, UsbFsIoctl>::new(command);
         ioctl::ioctl(fd, ctl)
     }
 }

--- a/src/platform/macos_iokit/device.rs
+++ b/src/platform/macos_iokit/device.rs
@@ -188,6 +188,13 @@ impl MacDevice {
             _event_registration,
         }))
     }
+
+    pub(crate) fn detach_and_claim_interface(
+        self: &Arc<Self>,
+        interface: u8,
+    ) -> Result<Arc<MacInterface>, Error> {
+        self.claim_interface(interface)
+    }
 }
 
 pub(crate) struct MacInterface {

--- a/src/platform/windows_winusb/device.rs
+++ b/src/platform/windows_winusb/device.rs
@@ -130,6 +130,13 @@ impl WindowsDevice {
             winusb_handle,
         }))
     }
+
+    pub(crate) fn detach_and_claim_interface(
+        self: &Arc<Self>,
+        interface: u8,
+    ) -> Result<Arc<WindowsInterface>, Error> {
+        self.claim_interface(interface)
+    }
 }
 
 pub(crate) struct WindowsInterface {


### PR DESCRIPTION
Closes #34 

Interestingly, the PR needs the fallback-to-racy code, otherwise it's not working on my ubuntu which is definitely not 12 years old (I'm getting "this ioctl is not valid for this device" error). Not sure what's going on there, maybe it's an undiscovered bug in libusb which I used as the source to port this code from. Or maybe I just can't copy code very well, as the number of force pushes here indicates :)