### PR TITLE
Fix interface string on macOS

### DIFF
--- a/src/platform/macos_iokit/enumeration.rs
+++ b/src/platform/macos_iokit/enumeration.rs
@@ -72,7 +72,7 @@ fn probe_device(device: IoService) -> Option<DeviceInfo> {
                     class: get_integer_property(&child, "bInterfaceClass")?,
                     subclass: get_integer_property(&child, "bInterfaceSubClass")?,
                     protocol: get_integer_property(&child, "bInterfaceProtocol")?,
-                    interface_string: get_string_property(&child, "USB Interface Name"),
+                    interface_string: get_string_property(&child, "kUSBString"),
                 })
             })
             .collect()

--- a/src/platform/macos_iokit/enumeration.rs
+++ b/src/platform/macos_iokit/enumeration.rs
@@ -72,7 +72,8 @@ fn probe_device(device: IoService) -> Option<DeviceInfo> {
                     class: get_integer_property(&child, "bInterfaceClass")?,
                     subclass: get_integer_property(&child, "bInterfaceSubClass")?,
                     protocol: get_integer_property(&child, "bInterfaceProtocol")?,
-                    interface_string: get_string_property(&child, "kUSBString"),
+                    interface_string: get_string_property(&child, "kUSBString")
+                        .or_else(|| get_string_property(&child, "USB Interface Name")),
                 })
             })
             .collect()


### PR DESCRIPTION
Use `kUSBHostInterfacePropertyString` (i.e. `"kUSBString"`) as the key when resolving the `interface_string` on macOS.

Fixes #36