### PR TITLE
Lower log level to `debug!()` for errors in enumeration.

### DIFF
--- a/src/platform/macos_iokit/enumeration.rs
+++ b/src/platform/macos_iokit/enumeration.rs
@@ -12,7 +12,7 @@ use io_kit_sys::{
     IORegistryEntryGetChildIterator, IORegistryEntryGetRegistryEntryID,
     IORegistryEntrySearchCFProperty, IOServiceGetMatchingServices, IOServiceMatching,
 };
-use log::{error, info, warn};
+use log::debug;
 
 use crate::{DeviceInfo, Error, InterfaceInfo, Speed};
 
@@ -47,7 +47,7 @@ pub(crate) fn service_by_registry_id(registry_id: u64) -> Result<IoService, Erro
 
 fn probe_device(device: IoService) -> Option<DeviceInfo> {
     let registry_id = get_id(&device)?;
-    log::info!("Probing device {registry_id}");
+    log::debug!("Probing device {registry_id}");
 
     // Can run `ioreg -p IOUSB -l` to see all properties
     Some(DeviceInfo {
@@ -90,7 +90,7 @@ fn get_id(device: &IoService) -> Option<u64> {
             Some(out)
         } else {
             // not sure this can actually fail.
-            error!("IORegistryEntryGetRegistryEntryID failed with {r}");
+            debug!("IORegistryEntryGetRegistryEntryID failed with {r}");
             None
         }
     }
@@ -109,14 +109,14 @@ fn get_property<T: ConcreteCFType>(device: &IoService, property: &'static str) -
         );
 
         if raw.is_null() {
-            info!("Device does not have property `{property}`");
+            debug!("Device does not have property `{property}`");
             return None;
         }
 
         let res = CFType::wrap_under_create_rule(raw).downcast_into();
 
         if res.is_none() {
-            error!("Failed to convert device property `{property}`");
+            debug!("Failed to convert device property `{property}`");
         }
 
         res
@@ -139,7 +139,7 @@ fn get_children(device: &IoService) -> Result<IoServiceIterator, Error> {
         let r =
             IORegistryEntryGetChildIterator(device.get(), kIOServicePlane as *mut _, &mut iterator);
         if r != kIOReturnSuccess {
-            warn!("IORegistryEntryGetChildIterator failed: {r}");
+            debug!("IORegistryEntryGetChildIterator failed: {r}");
             return Err(Error::from_raw_os_error(r));
         }
 

--- a/src/platform/windows_winusb/cfgmgr32.rs
+++ b/src/platform/windows_winusb/cfgmgr32.rs
@@ -1,6 +1,6 @@
 use std::{ffi::OsString, iter, mem, ptr};
 
-use log::error;
+use log::debug;
 use windows_sys::{
     core::GUID,
     Win32::{
@@ -220,7 +220,7 @@ pub fn list_interfaces(interface: GUID, instance_id: Option<&WCStr>) -> NulSepLi
 
         if cr != CR_SUCCESS {
             buf.clear();
-            error!("CM_Get_Device_Interface_List_SizeW failed, status {cr}");
+            debug!("CM_Get_Device_Interface_List_SizeW failed, status {cr}");
             break;
         }
 
@@ -242,7 +242,7 @@ pub fn list_interfaces(interface: GUID, instance_id: Option<&WCStr>) -> NulSepLi
             continue;
         } else {
             buf.clear();
-            error!("CM_Get_Device_Interface_ListW failed, status {cr}");
+            debug!("CM_Get_Device_Interface_ListW failed, status {cr}");
             break;
         }
     }

--- a/src/platform/windows_winusb/enumeration.rs
+++ b/src/platform/windows_winusb/enumeration.rs
@@ -3,7 +3,7 @@ use std::{
     ffi::{OsStr, OsString},
 };
 
-use log::{debug, error};
+use log::debug;
 use windows_sys::Win32::Devices::{
     Properties::{
         DEVPKEY_Device_Address, DEVPKEY_Device_BusNumber, DEVPKEY_Device_BusReportedDeviceDesc,
@@ -130,7 +130,7 @@ pub(crate) fn find_device_interfaces(dev: DevInst) -> HashMap<u8, WCString> {
         if let Some(path) = paths.iter().next() {
             interfaces.insert(0, path.to_owned());
         } else {
-            error!("Failed to find path for winusb device");
+            debug!("Failed to find path for winusb device");
         }
     }
 
@@ -145,7 +145,7 @@ fn get_interface_number(intf_dev: DevInst) -> Option<u8> {
         .iter()
         .find_map(|id| parse_hardware_id(id))
         .or_else(|| {
-            error!("Failed to parse interface number in hardware IDs: {hw_ids:?}");
+            debug!("Failed to parse interface number in hardware IDs: {hw_ids:?}");
             None
         })
 }
@@ -217,9 +217,9 @@ fn probe_interface(cdev: DevInst) -> Option<(u8, WCString)> {
             Ok(s) => s,
             Err(f) => {
                 if e.kind() == f.kind() {
-                    error!("Failed to get DeviceInterfaceGUID or DeviceInterfaceGUIDs from registry: {e}");
+                    debug!("Failed to get DeviceInterfaceGUID or DeviceInterfaceGUIDs from registry: {e}");
                 } else {
-                    error!("Failed to get DeviceInterfaceGUID or DeviceInterfaceGUIDs from registry: {e}, {f}");
+                    debug!("Failed to get DeviceInterfaceGUID or DeviceInterfaceGUIDs from registry: {e}, {f}");
                 }
                 return None;
             }
@@ -228,7 +228,7 @@ fn probe_interface(cdev: DevInst) -> Option<(u8, WCString)> {
 
     let paths = cdev.interfaces(guid);
     let Some(path) = paths.iter().next() else {
-        error!("Failed to find interface path");
+        debug!("Failed to find interface path");
         return None;
     };
 

--- a/src/platform/windows_winusb/hub.rs
+++ b/src/platform/windows_winusb/hub.rs
@@ -8,7 +8,7 @@ use std::{
     slice,
 };
 
-use log::{error, warn};
+use log::{debug, warn};
 use windows_sys::Win32::{
     Devices::{
         Properties::DEVPKEY_Device_Address,
@@ -36,14 +36,14 @@ impl HubHandle {
     pub fn by_devinst(devinst: DevInst) -> Option<HubHandle> {
         let paths = devinst.interfaces(GUID_DEVINTERFACE_USB_HUB);
         let Some(path) = paths.iter().next() else {
-            error!("Failed to find hub interface");
+            debug!("Failed to find hub interface");
             return None;
         };
 
         match create_file(path) {
             Ok(f) => Some(HubHandle(f)),
             Err(e) => {
-                error!("Failed to open hub: {e}");
+                debug!("Failed to open hub: {e}");
                 None
             }
         }
@@ -72,7 +72,7 @@ impl HubHandle {
                 Ok(info)
             } else {
                 let err = Error::last_os_error();
-                error!("Hub DeviceIoControl failed: {err:?}");
+                debug!("Hub DeviceIoControl failed: {err:?}");
                 Err(err)
             }
         }


### PR DESCRIPTION
https://github.com/kevinmehall/nusb/issues/38

These may not involve a device the app cares about, which results in noisy yet useless logs.