### PR TITLE
Cast RawOpcode to the internal ioctl_code type (c_uint)

### DIFF
--- a/src/platform/linux_usbfs/usbfs.rs
+++ b/src/platform/linux_usbfs/usbfs.rs
@@ -75,7 +75,7 @@ pub fn attach_kernel_driver<Fd: AsFd>(fd: Fd, interface: u8) -> io::Result<()> {
     unsafe {
         let command = UsbFsIoctl {
             interface: interface.into(),
-            ioctl_code: ioctl::NoneOpcode::<b'U', 23, ()>::OPCODE.raw(), // IOCTL_USBFS_CONNECT
+            ioctl_code: ioctl::NoneOpcode::<b'U', 23, ()>::OPCODE.raw() as c_uint, // IOCTL_USBFS_CONNECT
             data: std::ptr::null_mut(),
         };
         let ctl =


### PR DESCRIPTION
The rustix `RawOpcode` type can vary depending on the target.
For example, targets that use the libc Linux configuration in rustix, the `RawOpcode` type is a type alias to `c_ulong` rather than `c_uint`.
I believe the `UsbFsIoctl` struct should remain the same in these configurations.

Discovered this while attempting to build for `s390x-unknown-linux-gnu`.

```
error[E0308]: mismatched types
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nusb-0.1.6/src/platform/linux_usbfs/usbfs.rs:78:25
   |
78 |             ioctl_code: ioctl::NoneOpcode::<b'U', 23, ()>::OPCODE.raw(), // IOCTL_USBFS_CONNECT
   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `u64`
   ```