### PR TITLE
Mac: Update endpoints when interface alt setting is changed

### DIFF
--- a/src/platform/macos_iokit/device.rs
+++ b/src/platform/macos_iokit/device.rs
@@ -4,7 +4,7 @@ use std::{
     io::ErrorKind,
     sync::{
         atomic::{AtomicU8, Ordering},
-        Arc,
+        Arc, Mutex,
     },
     time::Duration,
 };
@@ -184,7 +184,7 @@ impl MacDevice {
             device: self.clone(),
             interface_number,
             interface,
-            endpoints,
+            endpoints: Mutex::new(endpoints),
             _event_registration,
         }))
     }
@@ -204,7 +204,7 @@ pub(crate) struct MacInterface {
     pub(crate) device: Arc<MacDevice>,
 
     /// Map from address to a structure that contains the `pipe_ref` used by iokit
-    pub(crate) endpoints: BTreeMap<u8, EndpointInfo>,
+    pub(crate) endpoints: Mutex<BTreeMap<u8, EndpointInfo>>,
 }
 
 impl MacInterface {
@@ -217,7 +217,8 @@ impl MacInterface {
             assert!(endpoint == 0);
             TransferHandle::new(super::TransferData::new_control(self.device.clone()))
         } else {
-            let endpoint = self.endpoints.get(&endpoint).expect("Endpoint not found");
+            let endpoints = self.endpoints.lock().unwrap();
+            let endpoint = endpoints.get(&endpoint).expect("Endpoint not found");
             TransferHandle::new(super::TransferData::new(
                 self.device.clone(),
                 self.clone(),
@@ -254,14 +255,20 @@ impl MacInterface {
             check_iokit_return(call_iokit_function!(
                 self.interface.raw,
                 SetAlternateInterface(alt_setting)
-            ))
+            ))?;
         }
+
+        let endpoints = self.interface.endpoints()?;
+        debug!("Found endpoints: {endpoints:?}");
+
+        *self.endpoints.lock().unwrap() = endpoints;
+        Ok(())
     }
 
     pub fn clear_halt(&self, endpoint: u8) -> Result<(), Error> {
         debug!("Clear halt, endpoint {endpoint:02x}");
-        let ep = self
-            .endpoints
+        let endpoints = self.endpoints.lock().unwrap();
+        let ep = endpoints
             .get(&endpoint)
             .ok_or_else(|| Error::new(ErrorKind::NotFound, "Endpoint not found"))?;
         unsafe {

--- a/src/platform/macos_iokit/iokit_usb.rs
+++ b/src/platform/macos_iokit/iokit_usb.rs
@@ -287,7 +287,7 @@ impl IoKitInterface {
         }
     }
 
-    pub(crate) fn endpoints(&mut self) -> Result<BTreeMap<u8, EndpointInfo>, Error> {
+    pub(crate) fn endpoints(&self) -> Result<BTreeMap<u8, EndpointInfo>, Error> {
         unsafe {
             let mut endpoints = BTreeMap::new();
             let mut count = 0;


### PR DESCRIPTION
The set of available endpoints can change when an interface's alt setting is changed, so on Mac we need to refresh our cached set of endpoints.

This necessitates wrapping the `BTreeMap` in a `Mutex` so it can be updated through the shared `self` reference in `set_alt_setting`.

I also changed `IoKitInterface::endpoints` to take a `&self` reference instead of `&mut self`. This seems sound from my inspection, but it should be reviewed carefully in case I missed something.
