### PR TITLE
Add `Device::claim_associated_interface`, `Interface::enable_raw_io`, `Interface::set_timeout_millisecond` for Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,18 @@ futures-lite = "1.13.0"
 rustix = { version = "0.38.17", features = ["fs", "event"] }
 
 [target.'cfg(target_os="windows")'.dependencies]
-windows-sys = { version = "0.48.0", features = ["Win32_Devices_Usb", "Win32_Devices_DeviceAndDriverInstallation", "Win32_Foundation", "Win32_Devices_Properties", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System_IO", "Win32_System_Registry", "Win32_System_Com"] }
+windows-sys = { version = "0.48.0", features = [
+    "Win32_Devices_Usb",
+    "Win32_Devices_DeviceAndDriverInstallation",
+    "Win32_Foundation",
+    "Win32_Devices_Properties",
+    "Win32_Storage_FileSystem",
+    "Win32_Security",
+    "Win32_System_IO",
+    "Win32_System_Registry",
+    "Win32_System_Com",
+    "Win32_System_SystemInformation",
+] }
 
 [target.'cfg(target_os="macos")'.dependencies]
 core-foundation = "0.9.3"

--- a/src/device.rs
+++ b/src/device.rs
@@ -469,6 +469,14 @@ impl Interface {
         TransferFuture::new(t)
     }
 
+    #[cfg(target_os = "windows")]
+    /// Enable RAW_IO for a single **IN (device-to-host)** transfer on the specified **bulk** endpoint.
+    ///
+    /// Enabling this should follow [this instruction](https://learn.microsoft.com/en-us/windows-hardware/drivers/usbcon/winusb-functions-for-pipe-policy-modification#:~:text=next%20read%20operation.-,RAW_IO,-Performance%20is%20a)
+    pub fn enable_raw_io(&self, endpoint: u8, enable: bool) {
+        self.backend.enable_raw_io(endpoint, enable);
+    }
+
     /// Submit a single **IN (device-to-host)** transfer on the specified **bulk** endpoint.
     ///
     /// * The requested length must be a multiple of the endpoint's maximum packet size

--- a/src/device.rs
+++ b/src/device.rs
@@ -52,6 +52,23 @@ impl Device {
         Ok(Interface { backend })
     }
 
+    #[cfg(target_os = "windows")]
+    /// Open an associated interface of the device and claim it for exclusive use.
+    ///
+    /// `default_interface` can be obtained by calling `claim_interface`.
+    ///
+    /// `interface` is assumed to be a non-zero `u8` (since `0_u8` is assumed to be the default interface)
+    pub fn claim_associated_interface(
+        &self,
+        default_interface: &Interface,
+        interface: u8,
+    ) -> Result<Interface, Error> {
+        let backend = self
+            .backend
+            .claim_associated_interface(&default_interface.backend, interface)?;
+        Ok(Interface { backend })
+    }
+
     /// Detach kernel drivers and open an interface of the device and claim it for exclusive use.
     ///
     /// ### Platform notes

--- a/src/device.rs
+++ b/src/device.rs
@@ -477,6 +477,18 @@ impl Interface {
         self.backend.enable_raw_io(endpoint, enable);
     }
 
+    #[cfg(target_os = "windows")]
+    /// Set transfers on an endpoint to complete within a specific time, in milliseconds
+    ///
+    /// * If set to zero (default), transfers won't time out because the host controller won't cancel the transfer. In this case, the transfer waits indefinitely until it's manually canceled or the transfer completes normally.
+    /// * If set to a nonzero value (time-out interval), the host controller starts a timer when it receives the transfer request. When the timer exceeds the set time-out interval, the request is canceled.
+    ///
+    /// Enabling this should follow [this instruction](https://learn.microsoft.com/en-us/windows-hardware/drivers/usbcon/winusb-functions-for-pipe-policy-modification#:~:text=next%20read%20operation.-,RAW_IO,-Performance%20is%20a)
+    pub fn set_timeout_millisecond(&self, endpoint: u8, timeout_millisecond: u32) {
+        self.backend
+            .set_timeout_millisecond(endpoint, timeout_millisecond);
+    }
+
     /// Submit a single **IN (device-to-host)** transfer on the specified **bulk** endpoint.
     ///
     /// * The requested length must be a multiple of the endpoint's maximum packet size

--- a/src/platform/windows_winusb/device.rs
+++ b/src/platform/windows_winusb/device.rs
@@ -256,9 +256,9 @@ impl WindowsInterface {
         };
 
         if r == 1 {
-            println!("value = {}", value);
+            debug!("WinUsb_GetPipePolicy succeeded to read MAXIMUM_TRANSFER_SIZE = {value}");
         } else {
-            println!("value = {value}, read error = {}", r);
+            warn!("WinUsb_GetPipePolicy failed to read MAXIMUM_TRANSFER_SIZE");
         }
     }
 

--- a/src/platform/windows_winusb/hub.rs
+++ b/src/platform/windows_winusb/hub.rs
@@ -124,13 +124,9 @@ impl HubHandle {
             );
             if r == TRUE {
                 let flags = info_v2.Flags.ul;
-                // update, if the device is super speed
+                // update, if the device is super speed. TODO : Not sure if the condition is appropriate
                 if flags & SUPER_SPEED == SUPER_SPEED {
-                    info.Speed = SUPER_SPEED as u8;
-                }
-                // update, if the device is super-plus speed
-                if flags & SUPER_PLUS_SPEED == SUPER_PLUS_SPEED {
-                    info.Speed = SUPER_PLUS_SPEED as u8;
+                    info.Speed = windows_sys::Win32::Devices::Usb::UsbSuperSpeed as u8;
                 }
             }
         };

--- a/src/platform/windows_winusb/transfer.rs
+++ b/src/platform/windows_winusb/transfer.rs
@@ -226,8 +226,8 @@ impl PlatformSubmit<RequestBuffer> for TransferData {
 
 impl PlatformSubmit<ControlIn> for TransferData {
     unsafe fn submit(&mut self, data: ControlIn, user_data: *mut c_void) {
-        assert_eq!(self.endpoint, 0);
-        assert_eq!(self.ep_type, EndpointType::Control);
+        debug_assert_eq!(self.endpoint, 0);
+        debug_assert_eq!(self.ep_type, EndpointType::Control);
 
         if data.recipient == Recipient::Interface
             && data.index as u8 != self.interface.interface_number
@@ -275,9 +275,10 @@ impl PlatformSubmit<ControlIn> for TransferData {
 
 impl PlatformSubmit<ControlOut<'_>> for TransferData {
     unsafe fn submit(&mut self, data: ControlOut, user_data: *mut c_void) {
-        assert_eq!(self.endpoint, 0);
-        assert_eq!(self.ep_type, EndpointType::Control);
+        debug_assert_eq!(self.endpoint, 0);
+        debug_assert_eq!(self.ep_type, EndpointType::Control);
 
+        #[cfg(debug_assertions)]
         if data.recipient == Recipient::Interface
             && data.index as u8 != self.interface.interface_number
         {

--- a/src/transfer/internal.rs
+++ b/src/transfer/internal.rs
@@ -111,7 +111,7 @@ impl<P: PlatformTransfer> TransferHandle<P> {
         // It's the syscall that submits the transfer that actually performs the
         // release ordering.
         let prev = self.inner().state.swap(STATE_PENDING, Ordering::Relaxed);
-        assert_eq!(prev, STATE_IDLE, "Transfer should be idle when submitted");
+        debug_assert_eq!(prev, STATE_IDLE, "Transfer should be idle when submitted");
 
         // SAFETY: while `TransferHandle` is alive, the only mutable access to `platform_data`
         // is via this `TransferHandle`. Verified that it is idle.


### PR DESCRIPTION
1. Add `Device::claim_associated_interface` for the composite device claiming an associated interface on Windows platform. 
Following your guidelines,  `WinUsb_GetAssociatedInterface` is used for composite device claiming *non-default* interfaces, with the following two assumptions that work for my test device ( I'm not sure if it is the general rule)
 * The interface `0` is the default interface used in WinUSB `WinUsb_Initialize`
 * Any other non-default interface has a positive (non-zero) interface number

2. Add `Interface::enable_raw_io` for Windows platform, which may be [useful in certain cases](https://learn.microsoft.com/en-us/windows-hardware/drivers/usbcon/winusb-functions-for-pipe-policy-modification#:~:text=next%20read%20operation.-,RAW_IO,-Performance%20is%20a)

3. Add `Interface::set_timeout_millisecond` for a transfer

4. Make several `assert_eq` to `debug_assert_eq` on some key bulk-in paths

6. Update `HubHandle::get_node_connection_info`, for getting a more precise connection speed (Fix the issue that super speed was mis-reported as high speed).

These additions can work but look to be ugly APIs and please just reallocate these snippets in a correct way if needed. 
