### PR TITLE
Declare minimum supported rust version as 1.74, and test this in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,11 +21,17 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        rust: ['stable', '1.74']
 
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v3
+    - name: Install toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust }}
+        override: true
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Kevin Mehall <km@kevinmehall.net>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/kevinmehall/nusb"
+rust-version = "1.74"
 
 [dependencies]
 atomic-waker = "1.1.2"


### PR DESCRIPTION
Currently `nusb` does not specify a minimum supported Rust version (MSRV). This information would be useful to have.

In the process of trying to minimise the MSRV for a downstream project, I found that nusb's MSRV is currently 1.74.

This PR declares that MSRV, and updates CI to test with both the MSRV and the latest stable release, to give a warning if the minimum becomes inaccurate.

It might be possible to reduce the MSRV, if that's of interest.

During testing I found that older releases such as 0.1.3 could be built with Rust 1.64.

Use of [`Option::is_some_and`](https://doc.rust-lang.org/std/option/enum.Option.html#method.is_some_and) raised the requirement to 1.70.

Use of [`OsStr::as_encoded_bytes`](https://doc.rust-lang.org/std/ffi/os_str/struct.OsStr.html#method.as_encoded_bytes) raised the requirement to 1.74.