### PR TITLE
Handle `ERROR_OPERATION_ABORTED` result when a transfer is cancelled

### DIFF
--- a/src/platform/windows_winusb/transfer.rs
+++ b/src/platform/windows_winusb/transfer.rs
@@ -14,8 +14,8 @@ use windows_sys::Win32::{
     },
     Foundation::{
         GetLastError, ERROR_DEVICE_NOT_CONNECTED, ERROR_FILE_NOT_FOUND, ERROR_GEN_FAILURE,
-        ERROR_IO_PENDING, ERROR_NOT_FOUND, ERROR_NO_SUCH_DEVICE, ERROR_REQUEST_ABORTED,
-        ERROR_SEM_TIMEOUT, ERROR_TIMEOUT, FALSE, TRUE, WIN32_ERROR,
+        ERROR_IO_PENDING, ERROR_NOT_FOUND, ERROR_NO_SUCH_DEVICE, ERROR_OPERATION_ABORTED,
+        ERROR_REQUEST_ABORTED, ERROR_SEM_TIMEOUT, ERROR_TIMEOUT, FALSE, TRUE, WIN32_ERROR,
     },
     System::IO::{CancelIoEx, OVERLAPPED},
 };
@@ -338,7 +338,9 @@ pub(super) fn handle_event(completion: *mut OVERLAPPED) {
 pub(crate) fn map_error(err: WIN32_ERROR) -> TransferError {
     match err {
         ERROR_GEN_FAILURE => TransferError::Stall,
-        ERROR_REQUEST_ABORTED | ERROR_TIMEOUT | ERROR_SEM_TIMEOUT => TransferError::Cancelled,
+        ERROR_REQUEST_ABORTED | ERROR_TIMEOUT | ERROR_SEM_TIMEOUT | ERROR_OPERATION_ABORTED => {
+            TransferError::Cancelled
+        }
         ERROR_FILE_NOT_FOUND | ERROR_DEVICE_NOT_CONNECTED | ERROR_NO_SUCH_DEVICE => {
             TransferError::Disconnected
         }


### PR DESCRIPTION
This result can be seen on Windows 10 while shutting down a bulk Queue (I was stopping capture in Packetry).

I believe it should be mapped to `TransferError::Cancelled`, and everything works as expected when I do so. This is also how it's [handled in libusb](https://github.com/libusb/libusb/blob/e678b3fad58a508cbd0a6e6dc777fb48346f948b/libusb/os/windows_common.c#L825-L831).

Since the error code was irreversibly mapped to `TransferError::Unknown`, it required patching nusb to find out what happened.

Perhaps `TransferError::Unknown` should have a field to retain an unexpected error code?

