### PR TITLE
Add DeviceInfo::port_chain

### DIFF
--- a/examples/descriptors.rs
+++ b/examples/descriptors.rs
@@ -10,7 +10,7 @@ fn main() {
 fn inspect_device(dev: DeviceInfo) {
     println!(
         "Device {:03}.{:03} ({:04x}:{:04x}) {} {}",
-        dev.bus_number(),
+        dev.bus_id(),
         dev.device_address(),
         dev.vendor_id(),
         dev.product_id(),

--- a/examples/string_descriptors.rs
+++ b/examples/string_descriptors.rs
@@ -12,7 +12,7 @@ fn main() {
 fn inspect_device(dev: DeviceInfo) {
     println!(
         "Device {:03}.{:03} ({:04x}:{:04x}) {} {}",
-        dev.bus_number(),
+        dev.bus_id(),
         dev.device_address(),
         dev.vendor_id(),
         dev.product_id(),

--- a/src/enumeration.rs
+++ b/src/enumeration.rs
@@ -51,7 +51,7 @@ pub struct DeviceInfo {
 
     pub(crate) bus_id: String,
     pub(crate) device_address: u8,
-    pub(crate) port_chain: Option<Vec<u8>>,
+    pub(crate) port_chain: Vec<u8>,
 
     pub(crate) vendor_id: u16,
     pub(crate) product_id: u16,
@@ -141,8 +141,8 @@ impl DeviceInfo {
     ///
     /// Since USB SuperSpeed is a separate topology from USB 2.0 speeds, a
     /// physical port may be identified differently depending on speed.
-    pub fn port_chain(&self) -> Option<&[u8]> {
-        self.port_chain.as_deref()
+    pub fn port_chain(&self) -> &[u8] {
+        &self.port_chain
     }
 
     /// *(Windows-only)* Driver associated with the device as a whole

--- a/src/enumeration.rs
+++ b/src/enumeration.rs
@@ -32,6 +32,9 @@ pub struct DeviceInfo {
     pub(crate) instance_id: OsString,
 
     #[cfg(target_os = "windows")]
+    pub(crate) location_paths: Vec<OsString>,
+
+    #[cfg(target_os = "windows")]
     pub(crate) parent_instance_id: OsString,
 
     #[cfg(target_os = "windows")]
@@ -120,6 +123,12 @@ impl DeviceInfo {
     #[cfg(target_os = "windows")]
     pub fn instance_id(&self) -> &OsStr {
         &self.instance_id
+    }
+
+    /// *(Windows-only)* Location paths property
+    #[cfg(target_os = "windows")]
+    pub fn location_paths(&self) -> &[OsString] {
+        &self.location_paths
     }
 
     /// *(Windows-only)* Instance ID path of the parent hub
@@ -312,6 +321,7 @@ impl std::fmt::Debug for DeviceInfo {
         {
             s.field("instance_id", &self.instance_id);
             s.field("parent_instance_id", &self.parent_instance_id);
+            s.field("location_paths", &self.location_paths);
             s.field("port_number", &self.port_number);
             s.field("driver", &self.driver);
         }

--- a/src/enumeration.rs
+++ b/src/enumeration.rs
@@ -123,12 +123,10 @@ impl DeviceInfo {
         self.port_number
     }
 
-    /// Path of port numbers identifying the physical port where the device is
-    /// connected.
+    /// Path of port numbers identifying the port where the device is connected.
     ///
-    /// The first value is the bus number, and subsequent values represent the
-    /// port used on each hub on the path to this device. The path is expected
-    /// to remain stable across device insertions or reboots.
+    /// Together with the bus ID, it identifies a physical port. The path is
+    ///  expected to remain stable across device insertions or reboots.
     ///
     /// Since USB SuperSpeed is a separate topology from USB 2.0 speeds, a
     /// physical port may be identified differently depending on speed.

--- a/src/enumeration.rs
+++ b/src/enumeration.rs
@@ -48,6 +48,7 @@ pub struct DeviceInfo {
 
     pub(crate) bus_number: u8,
     pub(crate) device_address: u8,
+    pub(crate) port_chain: Option<Vec<u8>>,
 
     pub(crate) vendor_id: u16,
     pub(crate) product_id: u16,
@@ -120,6 +121,19 @@ impl DeviceInfo {
     #[cfg(target_os = "windows")]
     pub fn port_number(&self) -> u32 {
         self.port_number
+    }
+
+    /// Path of port numbers identifying the physical port where the device is
+    /// connected.
+    ///
+    /// The first value is the bus number, and subsequent values represent the
+    /// port used on each hub on the path to this device. The path is expected
+    /// to remain stable across device insertions or reboots.
+    ///
+    /// Since USB SuperSpeed is a separate topology from USB 2.0 speeds, a
+    /// physical port may be identified differently depending on speed.
+    pub fn port_chain(&self) -> Option<&[u8]> {
+        self.port_chain.as_deref()
     }
 
     /// *(Windows-only)* Driver associated with the device as a whole
@@ -263,6 +277,7 @@ impl std::fmt::Debug for DeviceInfo {
 
         s.field("bus_number", &self.bus_number)
             .field("device_address", &self.device_address)
+            .field("port_chain", &format_args!("{:?}", self.port_chain))
             .field("vendor_id", &format_args!("0x{:04X}", self.vendor_id))
             .field("product_id", &format_args!("0x{:04X}", self.product_id))
             .field(

--- a/src/platform/linux_usbfs/device.rs
+++ b/src/platform/linux_usbfs/device.rs
@@ -46,7 +46,7 @@ pub(crate) struct LinuxDevice {
 
 impl LinuxDevice {
     pub(crate) fn from_device_info(d: &DeviceInfo) -> Result<Arc<LinuxDevice>, Error> {
-        let busnum = d.bus_number();
+        let busnum = d.busnum();
         let devnum = d.device_address();
         let active_config = d.path.read_attr("bConfigurationValue")?;
 

--- a/src/platform/linux_usbfs/enumeration.rs
+++ b/src/platform/linux_usbfs/enumeration.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::io;
+use std::iter;
 use std::num::ParseIntError;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -124,9 +125,20 @@ pub fn list_devices() -> Result<impl Iterator<Item = DeviceInfo>, Error> {
 
 pub fn probe_device(path: SysfsPath) -> Result<DeviceInfo, SysfsError> {
     debug!("Probing device {:?}", path.0);
+
+    let bus_number = path.read_attr("busnum")?;
+    let device_address = path.read_attr("devnum")?;
+
+    let port_chain = path.read_attr::<String>("devpath").ok().and_then(|p| {
+        iter::once(Some(bus_number))
+            .chain(p.split('.').map(|v| v.parse::<u8>().ok()))
+            .collect::<Option<Vec<u8>>>()
+    });
+
     Ok(DeviceInfo {
-        bus_number: path.read_attr("busnum")?,
-        device_address: path.read_attr("devnum")?,
+        bus_number,
+        device_address,
+        port_chain,
         vendor_id: path.read_attr_hex("idVendor")?,
         product_id: path.read_attr_hex("idProduct")?,
         device_version: path.read_attr_hex("bcdDevice")?,

--- a/src/platform/linux_usbfs/enumeration.rs
+++ b/src/platform/linux_usbfs/enumeration.rs
@@ -125,7 +125,7 @@ pub fn list_devices() -> Result<impl Iterator<Item = DeviceInfo>, Error> {
 pub fn probe_device(path: SysfsPath) -> Result<DeviceInfo, SysfsError> {
     debug!("Probing device {:?}", path.0);
 
-    let bus_number = path.read_attr("busnum")?;
+    let busnum = path.read_attr("busnum")?;
     let device_address = path.read_attr("devnum")?;
 
     let port_chain = path.read_attr::<String>("devpath").ok().and_then(|p| {
@@ -134,7 +134,8 @@ pub fn probe_device(path: SysfsPath) -> Result<DeviceInfo, SysfsError> {
             .collect::<Option<Vec<u8>>>()
     });
     Ok(DeviceInfo {
-        bus_number,
+        busnum,
+        bus_id: format!("{busnum:03}"),
         device_address,
         port_chain,
         vendor_id: path.read_attr_hex("idVendor")?,

--- a/src/platform/linux_usbfs/enumeration.rs
+++ b/src/platform/linux_usbfs/enumeration.rs
@@ -1,6 +1,5 @@
 use std::fs;
 use std::io;
-use std::iter;
 use std::num::ParseIntError;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -130,11 +129,10 @@ pub fn probe_device(path: SysfsPath) -> Result<DeviceInfo, SysfsError> {
     let device_address = path.read_attr("devnum")?;
 
     let port_chain = path.read_attr::<String>("devpath").ok().and_then(|p| {
-        iter::once(Some(bus_number))
-            .chain(p.split('.').map(|v| v.parse::<u8>().ok()))
+        p.split('.')
+            .map(|v| v.parse::<u8>().ok())
             .collect::<Option<Vec<u8>>>()
     });
-
     Ok(DeviceInfo {
         bus_number,
         device_address,

--- a/src/platform/linux_usbfs/enumeration.rs
+++ b/src/platform/linux_usbfs/enumeration.rs
@@ -128,11 +128,16 @@ pub fn probe_device(path: SysfsPath) -> Result<DeviceInfo, SysfsError> {
     let busnum = path.read_attr("busnum")?;
     let device_address = path.read_attr("devnum")?;
 
-    let port_chain = path.read_attr::<String>("devpath").ok().and_then(|p| {
-        p.split('.')
-            .map(|v| v.parse::<u8>().ok())
-            .collect::<Option<Vec<u8>>>()
-    });
+    let port_chain = path
+        .read_attr::<String>("devpath")
+        .ok()
+        .and_then(|p| {
+            p.split('.')
+                .map(|v| v.parse::<u8>().ok())
+                .collect::<Option<Vec<u8>>>()
+        })
+        .unwrap_or_default();
+
     Ok(DeviceInfo {
         busnum,
         bus_id: format!("{busnum:03}"),

--- a/src/platform/macos_iokit/enumeration.rs
+++ b/src/platform/macos_iokit/enumeration.rs
@@ -166,8 +166,7 @@ fn map_speed(speed: i64) -> Option<Speed> {
 }
 
 fn parse_location_id(id: u32) -> Vec<u8> {
-    let bus_num = id >> 24;
-    let mut chain = vec![bus_num as u8];
+    let mut chain = vec![];
     let mut shift = id << 8;
 
     while shift != 0 {
@@ -181,9 +180,9 @@ fn parse_location_id(id: u32) -> Vec<u8> {
 
 #[test]
 fn test_parse_location_id() {
-    assert_eq!(parse_location_id(0x01234567), vec![1, 2, 3, 4, 5, 6, 7]);
-    assert_eq!(parse_location_id(0xff875000), vec![255, 8, 7, 5]);
-    assert_eq!(parse_location_id(0x08400000), vec![8, 4]);
-    assert_eq!(parse_location_id(0x02040100), vec![2, 0, 4, 0, 1]);
-    assert_eq!(parse_location_id(0), vec![0]);
+    assert_eq!(parse_location_id(0x01234567), vec![2, 3, 4, 5, 6, 7]);
+    assert_eq!(parse_location_id(0xff875000), vec![8, 7, 5]);
+    assert_eq!(parse_location_id(0x08400000), vec![4]);
+    assert_eq!(parse_location_id(0x02040100), vec![0, 4, 0, 1]);
+    assert_eq!(parse_location_id(0), vec![]);
 }

--- a/src/platform/macos_iokit/enumeration.rs
+++ b/src/platform/macos_iokit/enumeration.rs
@@ -49,12 +49,15 @@ pub(crate) fn probe_device(device: IoService) -> Option<DeviceInfo> {
     let registry_id = get_registry_id(&device)?;
     log::debug!("Probing device {registry_id:08x}");
 
+    let location_id = get_integer_property(&device, "locationID")? as u32;
+
     // Can run `ioreg -p IOUSB -l` to see all properties
     Some(DeviceInfo {
         registry_id,
-        location_id: get_integer_property(&device, "locationID")? as u32,
-        bus_number: 0, // TODO: does this exist on macOS?
+        location_id,
+        bus_number: (location_id >> 24) as u8,
         device_address: get_integer_property(&device, "USB Address")? as u8,
+        port_chain: Some(parse_location_id(location_id)),
         vendor_id: get_integer_property(&device, "idVendor")? as u16,
         product_id: get_integer_property(&device, "idProduct")? as u16,
         device_version: get_integer_property(&device, "bcdDevice")? as u16,
@@ -160,4 +163,27 @@ fn map_speed(speed: i64) -> Option<Speed> {
         4 | 5 => Some(Speed::SuperPlus),
         _ => None,
     }
+}
+
+fn parse_location_id(id: u32) -> Vec<u8> {
+    let bus_num = id >> 24;
+    let mut chain = vec![bus_num as u8];
+    let mut shift = id << 8;
+
+    while shift != 0 {
+        let port = shift >> 28;
+        chain.push(port as u8);
+        shift = shift << 4;
+    }
+
+    chain
+}
+
+#[test]
+fn test_parse_location_id() {
+    assert_eq!(parse_location_id(0x01234567), vec![1, 2, 3, 4, 5, 6, 7]);
+    assert_eq!(parse_location_id(0xff875000), vec![255, 8, 7, 5]);
+    assert_eq!(parse_location_id(0x08400000), vec![8, 4]);
+    assert_eq!(parse_location_id(0x02040100), vec![2, 0, 4, 0, 1]);
+    assert_eq!(parse_location_id(0), vec![0]);
 }

--- a/src/platform/macos_iokit/enumeration.rs
+++ b/src/platform/macos_iokit/enumeration.rs
@@ -57,7 +57,7 @@ pub(crate) fn probe_device(device: IoService) -> Option<DeviceInfo> {
         location_id,
         bus_id: format!("{:02x}", (location_id >> 24) as u8),
         device_address: get_integer_property(&device, "USB Address")? as u8,
-        port_chain: Some(parse_location_id(location_id)),
+        port_chain: parse_location_id(location_id),
         vendor_id: get_integer_property(&device, "idVendor")? as u16,
         product_id: get_integer_property(&device, "idProduct")? as u16,
         device_version: get_integer_property(&device, "bcdDevice")? as u16,

--- a/src/platform/macos_iokit/enumeration.rs
+++ b/src/platform/macos_iokit/enumeration.rs
@@ -55,7 +55,7 @@ pub(crate) fn probe_device(device: IoService) -> Option<DeviceInfo> {
     Some(DeviceInfo {
         registry_id,
         location_id,
-        bus_number: (location_id >> 24) as u8,
+        bus_id: format!("{:02x}", (location_id >> 24) as u8),
         device_address: get_integer_property(&device, "USB Address")? as u8,
         port_chain: Some(parse_location_id(location_id)),
         vendor_id: get_integer_property(&device, "idVendor")? as u16,

--- a/src/platform/windows_winusb/enumeration.rs
+++ b/src/platform/windows_winusb/enumeration.rs
@@ -111,7 +111,7 @@ pub fn probe_device(devinst: DevInst) -> Option<DeviceInfo> {
         parent_instance_id,
         devinst,
         port_number,
-        port_chain: Some(port_chain),
+        port_chain,
         driver: Some(driver).filter(|s| !s.is_empty()),
         bus_id,
         device_address: info.address,

--- a/src/platform/windows_winusb/enumeration.rs
+++ b/src/platform/windows_winusb/enumeration.rs
@@ -108,6 +108,7 @@ pub fn probe_device(devinst: DevInst) -> Option<DeviceInfo> {
 
     Some(DeviceInfo {
         instance_id,
+        location_paths,
         parent_instance_id,
         devinst,
         port_number,

--- a/src/platform/windows_winusb/enumeration.rs
+++ b/src/platform/windows_winusb/enumeration.rs
@@ -100,7 +100,7 @@ pub fn probe_device(devinst: DevInst) -> Option<DeviceInfo> {
 
     let port_chain = devinst
         .get_property::<Vec<OsString>>(DEVPKEY_Device_LocationPaths)
-        .and_then(|s| s.iter().find_map(|p| parse_location_path(bus_number, p)));
+        .and_then(|s| s.iter().find_map(|p| parse_location_path(p)));
 
     Some(DeviceInfo {
         instance_id,
@@ -293,10 +293,10 @@ fn test_parse_compatible_id() {
     );
 }
 
-fn parse_location_path(bus_num: u8, s: &OsStr) -> Option<Vec<u8>> {
+fn parse_location_path(s: &OsStr) -> Option<Vec<u8>> {
     let (_, mut s) = s.to_str()?.split_once("#USBROOT(")?;
 
-    let mut path = vec![bus_num];
+    let mut path = vec![];
 
     while let Some((_, next)) = s.split_once("#USB(") {
         let (port_num, next) = next.split_once(")")?;
@@ -310,26 +310,21 @@ fn parse_location_path(bus_num: u8, s: &OsStr) -> Option<Vec<u8>> {
 #[test]
 fn test_parse_location_path() {
     assert_eq!(
-        parse_location_path(
-            0,
-            OsStr::new(
-                "PCIROOT(0)#PCI(0201)#PCI(0000)#USBROOT(0)#USB(23)#USB(2)#USB(1)#USB(3)#USB(4)"
-            )
-        ),
-        Some(vec![0, 23, 2, 1, 3, 4])
+        parse_location_path(OsStr::new(
+            "PCIROOT(0)#PCI(0201)#PCI(0000)#USBROOT(0)#USB(23)#USB(2)#USB(1)#USB(3)#USB(4)"
+        )),
+        Some(vec![23, 2, 1, 3, 4])
     );
     assert_eq!(
-        parse_location_path(
-            0,
-            OsStr::new("PCIROOT(0)#PCI(0201)#PCI(0000)#USBROOT(0)#USB(16)")
-        ),
-        Some(vec![0, 16])
+        parse_location_path(OsStr::new(
+            "PCIROOT(0)#PCI(0201)#PCI(0000)#USBROOT(0)#USB(16)"
+        )),
+        Some(vec![16])
     );
     assert_eq!(
-        parse_location_path(
-            0,
-            OsStr::new("ACPI(_SB_)#ACPI(PCI0)#ACPI(S11_)#ACPI(S00_)#ACPI(RHUB)#ACPI(HS04)")
-        ),
+        parse_location_path(OsStr::new(
+            "ACPI(_SB_)#ACPI(PCI0)#ACPI(S11_)#ACPI(S00_)#ACPI(RHUB)#ACPI(HS04)"
+        )),
         None
     );
 }

--- a/src/platform/windows_winusb/util.rs
+++ b/src/platform/windows_winusb/util.rs
@@ -167,7 +167,13 @@ impl<'a> Iterator for NulSepListIter<'a> {
         if let Some(next_nul) = self.0.iter().copied().position(|x| x == 0) {
             let (i, next) = self.0.split_at(next_nul + 1);
             self.0 = next;
-            Some(unsafe { WCStr::from_slice_unchecked(i) })
+
+            if i.len() <= 1 {
+                // Empty element (double `\0`) terminates the list
+                None
+            } else {
+                Some(unsafe { WCStr::from_slice_unchecked(i) })
+            }
         } else {
             None
         }


### PR DESCRIPTION
A simplified rewrite of @ccnut's https://github.com/kevinmehall/nusb/pull/58

```rs
/// Path of port numbers identifying the physical port where the device is
/// connected.
///
/// The first value is the bus number, and subsequent values represent the
/// port used on each hub on the path to this device. The path is expected
/// to remain stable across device insertions or reboots.
///
/// Since USB SuperSpeed is a separate topology from USB 2.0 speeds, a
/// physical port may be identified differently depending on speed.
pub fn port_chain(&self) -> Option<&[u8]>;
```

~~I've put the bus number at the beginning of the port chain, because the root hub port numbers are only unique within the bus. This makes it simpler to use as an identifier without getting the bus number separately. However, since the [bus number is wrong on Windows](https://github.com/kevinmehall/nusb/issues/70) and may not be a useful concept anyway, I might remove that.~~ (Removed)