### PR TITLE
Clean up logs on Linux

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        rust: ['stable', '1.74']
+        rust: ['stable', '1.76']
 
     runs-on: ${{ matrix.os }}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Kevin Mehall <km@kevinmehall.net>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/kevinmehall/nusb"
-rust-version = "1.74"
+rust-version = "1.76" # keep in sync with .github/workflows/rust.yml
 
 [dependencies]
 atomic-waker = "1.1.2"

--- a/src/platform/linux_usbfs/enumeration.rs
+++ b/src/platform/linux_usbfs/enumeration.rs
@@ -15,26 +15,59 @@ use crate::Speed;
 #[derive(Debug, Clone)]
 pub struct SysfsPath(pub(crate) PathBuf);
 
-impl SysfsPath {
-    pub(crate) fn read_attr<T: FromStr>(&self, attr: &str) -> Result<T, io::Error>
-    where
-        T: FromStr,
-        T::Err: std::error::Error + Send + Sync + 'static,
-    {
-        let attr_path = self.0.join(attr);
-        let read_res = fs::read_to_string(&attr_path);
-        debug!("sysfs read {attr_path:?}: {read_res:?}");
+#[derive(Debug)]
+pub struct SysfsError(PathBuf, SysfsErrorKind);
 
-        read_res?
-            .trim()
-            .parse()
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+#[derive(Debug)]
+enum SysfsErrorKind {
+    Io(io::Error),
+    Parse(String),
+}
+
+impl std::fmt::Display for SysfsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "failed to read sysfs attribute {}: ", self.0.display())?;
+        match &self.1 {
+            SysfsErrorKind::Io(e) => write!(f, "{e}"),
+            SysfsErrorKind::Parse(v) => write!(f, "couldn't parse value {:?}", v.trim()),
+        }
+    }
+}
+
+impl std::error::Error for SysfsError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self.1 {
+            SysfsErrorKind::Io(ref e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<SysfsError> for io::Error {
+    fn from(value: SysfsError) -> Self {
+        io::Error::other(Box::new(value))
+    }
+}
+
+impl SysfsPath {
+    fn parse_attr<T, E>(
+        &self,
+        attr: &str,
+        parse: impl FnOnce(&str) -> Result<T, E>,
+    ) -> Result<T, SysfsError> {
+        let attr_path = self.0.join(attr);
+        fs::read_to_string(&attr_path)
+            .map_err(SysfsErrorKind::Io)
+            .and_then(|v| parse(v.trim()).map_err(|_| SysfsErrorKind::Parse(v)))
+            .map_err(|e| SysfsError(attr_path, e))
     }
 
-    fn read_attr_hex<T: FromHexStr>(&self, attr: &str) -> Result<T, io::Error> {
-        let s = self.read_attr::<String>(attr)?;
-        T::from_hex_str(&s)
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid hex str"))
+    pub(crate) fn read_attr<T: FromStr>(&self, attr: &str) -> Result<T, SysfsError> {
+        self.parse_attr(attr, |s| s.parse())
+    }
+
+    fn read_attr_hex<T: FromHexStr>(&self, attr: &str) -> Result<T, SysfsError> {
+        self.parse_attr(attr, |s| T::from_hex_str(s))
     }
 
     fn children(&self) -> impl Iterator<Item = SysfsPath> {
@@ -89,8 +122,8 @@ pub fn list_devices() -> Result<impl Iterator<Item = DeviceInfo>, Error> {
     }))
 }
 
-pub fn probe_device(path: SysfsPath) -> Result<DeviceInfo, Error> {
-    debug!("probe device {path:?}");
+pub fn probe_device(path: SysfsPath) -> Result<DeviceInfo, SysfsError> {
+    debug!("Probing device {:?}", path.0);
     Ok(DeviceInfo {
         bus_number: path.read_attr("busnum")?,
         device_address: path.read_attr("devnum")?,

--- a/src/platform/linux_usbfs/events.rs
+++ b/src/platform/linux_usbfs/events.rs
@@ -76,7 +76,7 @@ fn event_loop() {
         retry_on_intr(|| epoll::wait(epoll_fd, &mut event_list, -1)).unwrap();
         for event in &event_list {
             let key = event.data.u64() as usize;
-            log::info!("event on {key}");
+            log::trace!("event on {key}");
             let lock = WATCHES.lock().unwrap();
             let Some(watch) = lock.get(key) else { continue };
 

--- a/src/platform/linux_usbfs/hotplug.rs
+++ b/src/platform/linux_usbfs/hotplug.rs
@@ -1,5 +1,5 @@
 use libc::{sockaddr, sockaddr_nl, socklen_t, AF_NETLINK, MSG_DONTWAIT};
-use log::{debug, error, warn};
+use log::{error, trace, warn};
 use rustix::{
     fd::{AsFd, AsRawFd, OwnedFd},
     net::{netlink, socket_with, AddressFamily, SocketFlags, SocketType},
@@ -127,7 +127,7 @@ fn parse_packet(buf: &[u8]) -> Option<HotplugEvent> {
     let mut devpath = None;
 
     for (k, v) in parse_properties(properties_buf) {
-        debug!("uevent property {k} = {v}");
+        trace!("uevent property {k} = {v}");
         match k {
             "SUBSYSTEM" if v != "usb" => return None,
             "DEVTYPE" if v != "usb_device" => return None,
@@ -161,7 +161,7 @@ fn parse_packet(buf: &[u8]) -> Option<HotplugEvent> {
         match probe_device(SysfsPath(path.clone())) {
             Ok(d) => Some(HotplugEvent::Connected(d)),
             Err(e) => {
-                error!("Failed to probe device {path:?}: {e}");
+                warn!("Failed to probe device {path:?}: {e}");
                 None
             }
         }


### PR DESCRIPTION
Better logs for real errors, fewer unnecessary logs.

Includes a functional change of ignoring root hubs -- they're not useful to open, not exposed on other
platforms, and sometimes slow to read properties from for some reason.

Increases MSRV to 1.76 for `Result::inspect_err`