### PR TITLE
Add bMaxPacketSize0 to DeviceInfo

### DIFF
--- a/src/enumeration.rs
+++ b/src/enumeration.rs
@@ -57,6 +57,8 @@ pub struct DeviceInfo {
     pub(crate) subclass: u8,
     pub(crate) protocol: u8,
 
+    pub(crate) max_packet_size: u8,
+
     pub(crate) speed: Option<Speed>,
 
     pub(crate) manufacturer_string: Option<String>,
@@ -187,6 +189,12 @@ impl DeviceInfo {
         self.protocol
     }
 
+    /// Maximum packet size for endpoint zero.
+    #[doc(alias = "bMaxPacketSize0")]
+    pub fn max_packet_size(&self) -> u8 {
+        self.max_packet_size
+    }
+
     /// Connection speed
     pub fn speed(&self) -> Option<Speed> {
         self.speed
@@ -264,6 +272,7 @@ impl std::fmt::Debug for DeviceInfo {
             .field("class", &format_args!("0x{:02X}", self.class))
             .field("subclass", &format_args!("0x{:02X}", self.subclass))
             .field("protocol", &format_args!("0x{:02X}", self.protocol))
+            .field("max_packet_size", &self.max_packet_size)
             .field("speed", &self.speed)
             .field("manufacturer_string", &self.manufacturer_string)
             .field("product_string", &self.product_string)

--- a/src/enumeration.rs
+++ b/src/enumeration.rs
@@ -57,7 +57,7 @@ pub struct DeviceInfo {
     pub(crate) subclass: u8,
     pub(crate) protocol: u8,
 
-    pub(crate) max_packet_size: u8,
+    pub(crate) max_packet_size_0: u8,
 
     pub(crate) speed: Option<Speed>,
 
@@ -191,8 +191,8 @@ impl DeviceInfo {
 
     /// Maximum packet size for endpoint zero.
     #[doc(alias = "bMaxPacketSize0")]
-    pub fn max_packet_size(&self) -> u8 {
-        self.max_packet_size
+    pub fn max_packet_size_0(&self) -> u8 {
+        self.max_packet_size_0
     }
 
     /// Connection speed
@@ -272,7 +272,7 @@ impl std::fmt::Debug for DeviceInfo {
             .field("class", &format_args!("0x{:02X}", self.class))
             .field("subclass", &format_args!("0x{:02X}", self.subclass))
             .field("protocol", &format_args!("0x{:02X}", self.protocol))
-            .field("max_packet_size", &self.max_packet_size)
+            .field("max_packet_size_0", &self.max_packet_size_0)
             .field("speed", &self.speed)
             .field("manufacturer_string", &self.manufacturer_string)
             .field("product_string", &self.product_string)

--- a/src/platform/linux_usbfs/enumeration.rs
+++ b/src/platform/linux_usbfs/enumeration.rs
@@ -133,7 +133,7 @@ pub fn probe_device(path: SysfsPath) -> Result<DeviceInfo, SysfsError> {
         class: path.read_attr_hex("bDeviceClass")?,
         subclass: path.read_attr_hex("bDeviceSubClass")?,
         protocol: path.read_attr_hex("bDeviceProtocol")?,
-        max_packet_size: path.read_attr("bMaxPacketSize0")?,
+        max_packet_size_0: path.read_attr("bMaxPacketSize0")?,
         speed: path
             .read_attr::<String>("speed")
             .ok()

--- a/src/platform/linux_usbfs/enumeration.rs
+++ b/src/platform/linux_usbfs/enumeration.rs
@@ -133,6 +133,7 @@ pub fn probe_device(path: SysfsPath) -> Result<DeviceInfo, SysfsError> {
         class: path.read_attr_hex("bDeviceClass")?,
         subclass: path.read_attr_hex("bDeviceSubClass")?,
         protocol: path.read_attr_hex("bDeviceProtocol")?,
+        max_packet_size: path.read_attr("bMaxPacketSize0")?,
         speed: path
             .read_attr::<String>("speed")
             .ok()

--- a/src/platform/macos_iokit/enumeration.rs
+++ b/src/platform/macos_iokit/enumeration.rs
@@ -61,7 +61,7 @@ pub(crate) fn probe_device(device: IoService) -> Option<DeviceInfo> {
         class: get_integer_property(&device, "bDeviceClass")? as u8,
         subclass: get_integer_property(&device, "bDeviceSubClass")? as u8,
         protocol: get_integer_property(&device, "bDeviceProtocol")? as u8,
-        max_packet_size: get_integer_property(&device, "bMaxPacketSize0")? as u8,
+        max_packet_size_0: get_integer_property(&device, "bMaxPacketSize0")? as u8,
         speed: get_integer_property(&device, "Device Speed").and_then(map_speed),
         manufacturer_string: get_string_property(&device, "USB Vendor Name"),
         product_string: get_string_property(&device, "USB Product Name"),

--- a/src/platform/macos_iokit/enumeration.rs
+++ b/src/platform/macos_iokit/enumeration.rs
@@ -61,6 +61,7 @@ pub(crate) fn probe_device(device: IoService) -> Option<DeviceInfo> {
         class: get_integer_property(&device, "bDeviceClass")? as u8,
         subclass: get_integer_property(&device, "bDeviceSubClass")? as u8,
         protocol: get_integer_property(&device, "bDeviceProtocol")? as u8,
+        max_packet_size: get_integer_property(&device, "bMaxPacketSize0")? as u8,
         speed: get_integer_property(&device, "Device Speed").and_then(map_speed),
         manufacturer_string: get_string_property(&device, "USB Vendor Name"),
         product_string: get_string_property(&device, "USB Product Name"),

--- a/src/platform/windows_winusb/enumeration.rs
+++ b/src/platform/windows_winusb/enumeration.rs
@@ -112,7 +112,7 @@ pub fn probe_device(devinst: DevInst) -> Option<DeviceInfo> {
         class: info.device_desc.bDeviceClass,
         subclass: info.device_desc.bDeviceSubClass,
         protocol: info.device_desc.bDeviceProtocol,
-        max_packet_size: info.device_desc.bMaxPacketSize0,
+        max_packet_size_0: info.device_desc.bMaxPacketSize0,
         speed: info.speed,
         manufacturer_string: None,
         product_string,

--- a/src/platform/windows_winusb/enumeration.rs
+++ b/src/platform/windows_winusb/enumeration.rs
@@ -112,6 +112,7 @@ pub fn probe_device(devinst: DevInst) -> Option<DeviceInfo> {
         class: info.device_desc.bDeviceClass,
         subclass: info.device_desc.bDeviceSubClass,
         protocol: info.device_desc.bDeviceProtocol,
+        max_packet_size: info.device_desc.bMaxPacketSize0,
         speed: info.speed,
         manufacturer_string: None,
         product_string,


### PR DESCRIPTION
Not sure if this was not included intentionally or just missed. The bMaxPacketSize0 - packet size for endpoint zero that all devices must support - is included in the cached Device Descriptor on all platforms so seems sensible to include.