### PR TITLE
Android support for non-rooted phones

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ matrix.rust }}
         override: true
@@ -36,3 +36,16 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+
+  build_android:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: 'aarch64-linux-android, armv7-linux-androideabi'
+    - name: build
+      run: |
+        cargo build --target aarch64-linux-android --all-features
+        cargo build --target armv7-linux-androideabi --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ slab = "0.4.9"
 env_logger = "0.10.0"
 futures-lite = "1.13.0"
 
-[target.'cfg(target_os="linux")'.dependencies]
+[target.'cfg(any(target_os="linux", target_os="android"))'.dependencies]
 rustix = { version = "0.38.17", features = ["fs", "event", "net"] }
 libc = "0.2.155"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.76" # keep in sync with .github/workflows/rust.yml
 [dependencies]
 atomic-waker = "1.1.2"
 futures-core = "0.3.29"
+libc = "0.2.155"
 log = "0.4.20"
 once_cell = "1.18.0"
 slab = "0.4.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = "1.76" # keep in sync with .github/workflows/rust.yml
 [dependencies]
 atomic-waker = "1.1.2"
 futures-core = "0.3.29"
-libc = "0.2.155"
 log = "0.4.20"
 once_cell = "1.18.0"
 slab = "0.4.9"

--- a/src/device.rs
+++ b/src/device.rs
@@ -74,7 +74,7 @@ impl Device {
     /// This function can only detach kernel drivers on Linux. Calling on other platforms has
     /// no effect.
     pub fn detach_kernel_driver(&self, interface: u8) -> Result<(), Error> {
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(target_os = "linux")]
         self.backend.detach_kernel_driver(interface)?;
         let _ = interface;
 
@@ -87,7 +87,7 @@ impl Device {
     /// This function can only attach kernel drivers on Linux. Calling on other platforms has
     /// no effect.
     pub fn attach_kernel_driver(&self, interface: u8) -> Result<(), Error> {
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(target_os = "linux")]
         self.backend.attach_kernel_driver(interface)?;
         let _ = interface;
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -11,7 +11,6 @@ use crate::{
     DeviceInfo, Error,
 };
 use log::error;
-use rustix::fd::OwnedFd;
 use std::{io::ErrorKind, sync::Arc, time::Duration};
 
 /// An opened USB device.
@@ -47,7 +46,7 @@ impl Device {
 
     /// Wraps a device that is already open.
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    pub fn from_fd(fd: OwnedFd) -> Result<Device, Error> {
+    pub fn from_fd(fd: std::os::fd::OwnedFd) -> Result<Device, Error> {
         Ok(Device {
             backend: platform::Device::from_fd(fd)?,
         })

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,7 +1,3 @@
-use std::{io::ErrorKind, sync::Arc, time::Duration};
-
-use log::error;
-
 use crate::{
     descriptors::{
         decode_string_descriptor, validate_string_descriptor, ActiveConfigurationError,
@@ -14,6 +10,9 @@ use crate::{
     },
     DeviceInfo, Error,
 };
+use log::error;
+use rustix::fd::OwnedFd;
+use std::{io::ErrorKind, sync::Arc, time::Duration};
 
 /// An opened USB device.
 ///
@@ -44,6 +43,14 @@ impl Device {
     pub(crate) fn open(d: &DeviceInfo) -> Result<Device, std::io::Error> {
         let backend = platform::Device::from_device_info(d)?;
         Ok(Device { backend })
+    }
+
+    /// Wraps a device that is already open.
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    pub fn from_fd(fd: OwnedFd) -> Result<Device, Error> {
+        Ok(Device {
+            backend: platform::Device::from_fd(fd)?,
+        })
     }
 
     /// Open an interface of the device and claim it for exclusive use.

--- a/src/device.rs
+++ b/src/device.rs
@@ -68,7 +68,7 @@ impl Device {
     /// This function can only detach kernel drivers on Linux. Calling on other platforms has
     /// no effect.
     pub fn detach_kernel_driver(&self, interface: u8) -> Result<(), Error> {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         self.backend.detach_kernel_driver(interface)?;
         let _ = interface;
 
@@ -81,7 +81,7 @@ impl Device {
     /// This function can only attach kernel drivers on Linux. Calling on other platforms has
     /// no effect.
     pub fn attach_kernel_driver(&self, interface: u8) -> Result<(), Error> {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         self.backend.attach_kernel_driver(interface)?;
         let _ = interface;
 
@@ -242,7 +242,7 @@ impl Device {
     ///   and use the interface handle to submit transfers.
     /// * On Linux, this takes a device-wide lock, so if you have multiple threads, you
     ///   are better off using the async methods.
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "android"))]
     pub fn control_in_blocking(
         &self,
         control: Control,
@@ -260,7 +260,7 @@ impl Device {
     ///   and use the interface handle to submit transfers.
     /// * On Linux, this takes a device-wide lock, so if you have multiple threads, you
     ///   are better off using the async methods.
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "android"))]
     pub fn control_out_blocking(
         &self,
         control: Control,
@@ -296,7 +296,7 @@ impl Device {
     ///
     /// * Not supported on Windows. You must [claim an interface][`Device::claim_interface`]
     ///   and use the interface handle to submit transfers.
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "android"))]
     pub fn control_in(&self, data: ControlIn) -> TransferFuture<ControlIn> {
         let mut t = self.backend.make_control_transfer();
         t.submit::<ControlIn>(data);
@@ -329,7 +329,7 @@ impl Device {
     ///
     /// * Not supported on Windows. You must [claim an interface][`Device::claim_interface`]
     ///   and use the interface handle to submit transfers.
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "android"))]
     pub fn control_out(&self, data: ControlOut) -> TransferFuture<ControlOut> {
         let mut t = self.backend.make_control_transfer();
         t.submit::<ControlOut>(data);

--- a/src/enumeration.rs
+++ b/src/enumeration.rs
@@ -100,13 +100,13 @@ impl DeviceInfo {
     /// *(Linux-only)* Sysfs path for the device.
     #[doc(hidden)]
     #[deprecated = "use `sysfs_path()` instead"]
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(target_os = "linux")]
     pub fn path(&self) -> &SysfsPath {
         &self.path
     }
 
     /// *(Linux-only)* Sysfs path for the device.
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(target_os = "linux")]
     pub fn sysfs_path(&self) -> &std::path::Path {
         &self.path.0
     }
@@ -311,9 +311,12 @@ impl std::fmt::Debug for DeviceInfo {
             .field("product_string", &self.product_string)
             .field("serial_number", &self.serial_number);
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(target_os = "linux")]
         {
             s.field("sysfs_path", &self.path);
+        }
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        {
             s.field("busnum", &self.busnum);
         }
 

--- a/src/enumeration.rs
+++ b/src/enumeration.rs
@@ -1,7 +1,7 @@
 #[cfg(target_os = "windows")]
 use std::ffi::{OsStr, OsString};
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use crate::platform::SysfsPath;
 
 use crate::{Device, Error};
@@ -22,10 +22,10 @@ pub struct DeviceId(pub(crate) crate::platform::DeviceId);
 ///     * macOS: `registry_id`, `location_id`
 #[derive(Clone)]
 pub struct DeviceInfo {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub(crate) path: SysfsPath,
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub(crate) busnum: u8,
 
     #[cfg(target_os = "windows")]
@@ -83,7 +83,7 @@ impl DeviceInfo {
             DeviceId(self.devinst)
         }
 
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             DeviceId(crate::platform::DeviceId {
                 bus: self.busnum,
@@ -100,13 +100,13 @@ impl DeviceInfo {
     /// *(Linux-only)* Sysfs path for the device.
     #[doc(hidden)]
     #[deprecated = "use `sysfs_path()` instead"]
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn path(&self) -> &SysfsPath {
         &self.path
     }
 
     /// *(Linux-only)* Sysfs path for the device.
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn sysfs_path(&self) -> &std::path::Path {
         &self.path.0
     }
@@ -114,7 +114,7 @@ impl DeviceInfo {
     /// *(Linux-only)* Bus number.
     ///
     /// On Linux, the `bus_id` is an integer and this provides the value as `u8`.
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn busnum(&self) -> u8 {
         self.busnum
     }
@@ -311,7 +311,7 @@ impl std::fmt::Debug for DeviceInfo {
             .field("product_string", &self.product_string)
             .field("serial_number", &self.serial_number);
 
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             s.field("sysfs_path", &self.path);
             s.field("busnum", &self.busnum);

--- a/src/platform/linux_usbfs/usbfs.rs
+++ b/src/platform/linux_usbfs/usbfs.rs
@@ -95,7 +95,7 @@ mod opcodes {
 pub fn detach_kernel_driver<Fd: AsFd>(fd: Fd, interface: u8) -> io::Result<()> {
     let command = UsbFsIoctl {
         interface: interface.into(),
-        ioctl_code: opcodes::nested::USBDEVFS_DISCONNECT::OPCODE.raw() as _,
+        ioctl_code: opcodes::nested::USBDEVFS_DISCONNECT::OPCODE.raw(),
         data: std::ptr::null_mut(),
     };
     unsafe {
@@ -107,7 +107,7 @@ pub fn detach_kernel_driver<Fd: AsFd>(fd: Fd, interface: u8) -> io::Result<()> {
 pub fn attach_kernel_driver<Fd: AsFd>(fd: Fd, interface: u8) -> io::Result<()> {
     let command = UsbFsIoctl {
         interface: interface.into(),
-        ioctl_code: opcodes::nested::USBDEVFS_CONNECT::OPCODE.raw() as _,
+        ioctl_code: opcodes::nested::USBDEVFS_CONNECT::OPCODE.raw(),
         data: std::ptr::null_mut(),
     };
     unsafe {

--- a/src/platform/linux_usbfs/usbfs.rs
+++ b/src/platform/linux_usbfs/usbfs.rs
@@ -95,7 +95,8 @@ mod opcodes {
 pub fn detach_kernel_driver<Fd: AsFd>(fd: Fd, interface: u8) -> io::Result<()> {
     let command = UsbFsIoctl {
         interface: interface.into(),
-        ioctl_code: opcodes::nested::USBDEVFS_DISCONNECT::OPCODE.raw(),
+        // NOTE: Cast needed since on android this type is i32 vs u32 on linux
+        ioctl_code: opcodes::nested::USBDEVFS_DISCONNECT::OPCODE.raw() as _,
         data: std::ptr::null_mut(),
     };
     unsafe {
@@ -107,7 +108,7 @@ pub fn detach_kernel_driver<Fd: AsFd>(fd: Fd, interface: u8) -> io::Result<()> {
 pub fn attach_kernel_driver<Fd: AsFd>(fd: Fd, interface: u8) -> io::Result<()> {
     let command = UsbFsIoctl {
         interface: interface.into(),
-        ioctl_code: opcodes::nested::USBDEVFS_CONNECT::OPCODE.raw(),
+        ioctl_code: opcodes::nested::USBDEVFS_CONNECT::OPCODE.raw() as _,
         data: std::ptr::null_mut(),
     };
     unsafe {

--- a/src/platform/linux_usbfs/usbfs.rs
+++ b/src/platform/linux_usbfs/usbfs.rs
@@ -95,7 +95,7 @@ mod opcodes {
 pub fn detach_kernel_driver<Fd: AsFd>(fd: Fd, interface: u8) -> io::Result<()> {
     let command = UsbFsIoctl {
         interface: interface.into(),
-        ioctl_code: opcodes::nested::USBDEVFS_DISCONNECT::OPCODE.raw(),
+        ioctl_code: opcodes::nested::USBDEVFS_DISCONNECT::OPCODE.raw() as _,
         data: std::ptr::null_mut(),
     };
     unsafe {
@@ -107,7 +107,7 @@ pub fn detach_kernel_driver<Fd: AsFd>(fd: Fd, interface: u8) -> io::Result<()> {
 pub fn attach_kernel_driver<Fd: AsFd>(fd: Fd, interface: u8) -> io::Result<()> {
     let command = UsbFsIoctl {
         interface: interface.into(),
-        ioctl_code: opcodes::nested::USBDEVFS_CONNECT::OPCODE.raw(),
+        ioctl_code: opcodes::nested::USBDEVFS_CONNECT::OPCODE.raw() as _,
         data: std::ptr::null_mut(),
     };
     unsafe {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,7 +1,7 @@
-//#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 mod linux_usbfs;
 
-//#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub use linux_usbfs::*;
 
 #[cfg(target_os = "windows")]
@@ -10,8 +10,8 @@ mod windows_winusb;
 #[cfg(target_os = "windows")]
 pub use windows_winusb::*;
 
-// #[cfg(target_os = "macos")]
-// mod macos_iokit;
-// 
-// #[cfg(target_os = "macos")]
-// pub use macos_iokit::*;
+#[cfg(target_os = "macos")]
+mod macos_iokit;
+
+#[cfg(target_os = "macos")]
+pub use macos_iokit::*;

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,7 +1,7 @@
-#[cfg(any(target_os = "linux", target_os = "android"))]
+//#[cfg(any(target_os = "linux", target_os = "android"))]
 mod linux_usbfs;
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+//#[cfg(any(target_os = "linux", target_os = "android"))]
 pub use linux_usbfs::*;
 
 #[cfg(target_os = "windows")]
@@ -10,8 +10,8 @@ mod windows_winusb;
 #[cfg(target_os = "windows")]
 pub use windows_winusb::*;
 
-#[cfg(target_os = "macos")]
-mod macos_iokit;
-
-#[cfg(target_os = "macos")]
-pub use macos_iokit::*;
+// #[cfg(target_os = "macos")]
+// mod macos_iokit;
+// 
+// #[cfg(target_os = "macos")]
+// pub use macos_iokit::*;

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,7 +1,7 @@
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 mod linux_usbfs;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub use linux_usbfs::*;
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
Adds a `Device::from_fd` function for wrapping devices obtained from android's [UsbManager](https://developer.android.com/reference/android/hardware/usb/UsbManager)

### Testing

Tested with HackrfOne (firmware version `2024.02.1`) on an A7 lite running Android 14 (kernel version `4.19.191`).

The basic configuration methods work, as well as receiving from bulk endpoints via the async Queue interface: 
See: https://github.com/MerchGuardian/seify/blob/hackrf/crates/hackrf-one-rs/src/lib.rs#L535-L566

```
let dev = nusb::Device::from_fd(fd).unwrap();

for config in dev.configurations() {
    log::info!("Got config: {:?}", config);

    log::info!("num_interfaces: {:?}", config.num_interfaces());
    log::info!("configuration_value: {:?}", config.configuration_value());

    log::info!("attributes: {:?}", config.attributes());
    log::info!("max_power: {:?}", config.max_power());
    let string_index = config.string_index().unwrap();
    log::info!("string_index: {:?}", string_index);

    for lang in dev.get_string_descriptor_supported_languages(Duration::from_millis(500)).unwrap() {
        log::info!("Got lang: {lang:?}");
        let s = dev.get_string_descriptor(string_index, lang, Duration::from_millis(500)).unwrap();
        log::info!("str descriptor: {s:?}");
    }
}
```

Prints:

```
INFO:android_test - Got config: Configuration {
    configuration_value: 1,
    num_interfaces: 1,
    attributes: 128,
    max_power: 250,
    string_index: Some(
        3,
    ),
    interface_alt_settings: [
        InterfaceAltSetting {
            interface_number: 0,
            alternate_setting: 0,
            num_endpoints: 2,
            class: 255,
            subclass: 255,
            protocol: 255,
            string_index: None,
            endpoints: [
                Endpoint {
                    address: 0x81,
                    direction: In,
                    transfer_type: Bulk,
                    max_packet_size: 512,
                    packets_per_microframe: 1,
                    interval: 0,
                },
                Endpoint {
                    address: 0x02,
                    direction: Out,
                    transfer_type: Bulk,
                    max_packet_size: 512,
                    packets_per_microframe: 1,
                    interval: 0,
                },
            ],
        },
    ],
}
INFO:android_test - num_interfaces: 1
INFO:android_test - configuration_value: 1
INFO:android_test - attributes: 128
INFO:android_test - max_power: 250
INFO:android_test - string_index: 3
INFO:android_test - Got lang: 1033
INFO:android_test - str descriptor: "Transceiver"
```

TODO:
* Add CI job that builds with `cargo ndk` to ensure we hit the new `#[cfg(target_os = "android")] blocks in CI