### PR TITLE
Windows: include hub devices in list like other platforms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,9 +142,6 @@ pub type Error = io::Error;
 ///     .find(|dev| dev.vendor_id() == 0xAAAA && dev.product_id() == 0xBBBB)
 ///     .expect("device not connected");
 /// ```
-///
-/// ### Platform-specific notes
-/// * On Windows, hubs are not included in the list
 pub fn list_devices() -> Result<impl Iterator<Item = DeviceInfo>, Error> {
     platform::list_devices()
 }


### PR DESCRIPTION
I note there is [mention](https://github.com/kevinmehall/nusb/blob/main/src/lib.rs#L147) of this in the docs but is it intended or just the nature of only using `GUID_DEVINTERFACE_USB_DEVICE`? Since importing `GUID_DEVINTERFACE_USB_HUB` for the `list_buses`, I realise that non-root hubs can be obtained with this too in the `list_devices()`.

I believe it makes since to add it so hubs are included in the device list. If only because it makes Windows listing the same as the other platforms. I also think it makes sense as hub are devices and descriptors can be read, control messages used etc. unlike root hubs.