### PR TITLE
macOS: Fix set_configuration and reset by using USBDeviceOpen

### DIFF
--- a/src/platform/macos_iokit/iokit.rs
+++ b/src/platform/macos_iokit/iokit.rs
@@ -4,10 +4,7 @@
 //! licensed under MIT OR Apache-2.0.
 
 use core_foundation_sys::uuid::CFUUIDBytes;
-use io_kit_sys::{
-    ret::{kIOReturnExclusiveAccess, kIOReturnSuccess, IOReturn},
-    IOIteratorNext, IOObjectRelease,
-};
+use io_kit_sys::{ret::IOReturn, IOIteratorNext, IOObjectRelease};
 use std::io::ErrorKind;
 
 use crate::Error;
@@ -124,11 +121,12 @@ pub(crate) fn check_iokit_return(r: IOReturn) -> Result<(), Error> {
     #[allow(non_upper_case_globals)]
     #[deny(unreachable_patterns)]
     match r {
-        kIOReturnSuccess => Ok(()),
-        kIOReturnExclusiveAccess => Err(Error::new(
+        io_kit_sys::ret::kIOReturnSuccess => Ok(()),
+        io_kit_sys::ret::kIOReturnExclusiveAccess => Err(Error::new(
             ErrorKind::Other,
-            "Could not be opened for exclusive access",
+            "could not be opened for exclusive access",
         )),
+        io_kit_sys::ret::kIOReturnNotFound => Err(Error::new(ErrorKind::NotFound, "not found")),
         _ => Err(Error::from_raw_os_error(r)),
     }
 }

--- a/src/platform/macos_iokit/mod.rs
+++ b/src/platform/macos_iokit/mod.rs
@@ -1,7 +1,5 @@
 mod transfer;
-use io_kit_sys::ret::{
-    kIOReturnAborted, kIOReturnNoDevice, kIOReturnSuccess, kIOReturnUnderrun, IOReturn,
-};
+use io_kit_sys::ret::IOReturn;
 pub(crate) use transfer::TransferData;
 
 mod enumeration;
@@ -28,9 +26,10 @@ fn status_to_transfer_result(status: IOReturn) -> Result<(), TransferError> {
     #[allow(non_upper_case_globals)]
     #[deny(unreachable_patterns)]
     match status {
-        kIOReturnSuccess | kIOReturnUnderrun => Ok(()),
-        kIOReturnNoDevice => Err(TransferError::Disconnected),
-        kIOReturnAborted => Err(TransferError::Cancelled),
+        io_kit_sys::ret::kIOReturnSuccess | io_kit_sys::ret::kIOReturnUnderrun => Ok(()),
+        io_kit_sys::ret::kIOReturnNoDevice => Err(TransferError::Disconnected),
+        io_kit_sys::ret::kIOReturnAborted => Err(TransferError::Cancelled),
+        iokit_c::kIOUSBPipeStalled => Err(TransferError::Stall),
         _ => Err(TransferError::Unknown),
     }
 }


### PR DESCRIPTION
Fixes #87 

`USBDeviceOpen` is not required for claiming interfaces. The documentation says it's required for control transfers, but it works without. It is, however, required for `set_configuration` and `reset`.

Having an interface claimed does not cause `set_configuration` and `reset` to fail on macOS like it does on Linux. After doing some testing, I ended up doing what libusb does and attempting to `USBDeviceOpen` when opening a device to try to get exclusive access, but ignoring failures, and trying again and requiring success only before `set_configuration` and `reset`. That's not perfect -- you can be the second process to open a device and fail  `USBDeviceOpen`, then the first process closes it, and a third process is then able to call these methods, but I can't find a better way.
