### PR TITLE
Make blocking APIs optionally async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,8 @@ core-foundation = "0.9.3"
 core-foundation-sys = "0.8.4"
 io-kit-sys = "0.4.0"
 
+[target.'cfg(any(target_os="linux", target_os="android", target_os="windows", target_os="macos"))'.dependencies]
+blocking ="1.6.1"
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/examples/blocking.rs
+++ b/examples/blocking.rs
@@ -1,17 +1,21 @@
 use std::time::Duration;
 
-use nusb::transfer::{Control, ControlType, Recipient};
+use nusb::{
+    transfer::{Control, ControlType, Recipient},
+    IoAction,
+};
 
 fn main() {
     env_logger::init();
     let di = nusb::list_devices()
+        .wait()
         .unwrap()
         .find(|d| d.vendor_id() == 0x59e3 && d.product_id() == 0x0a23)
         .expect("device should be connected");
 
     println!("Device info: {di:?}");
 
-    let device = di.open().unwrap();
+    let device = di.open().wait().unwrap();
 
     // Linux can make control transfers without claiming an interface
     #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -49,7 +53,7 @@ fn main() {
     }
 
     // but we also provide an API on the `Interface` to support Windows
-    let interface = device.claim_interface(0).unwrap();
+    let interface = device.claim_interface(0).wait().unwrap();
 
     let result = interface.control_out_blocking(
         Control {

--- a/examples/blocking.rs
+++ b/examples/blocking.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use nusb::{
     transfer::{Control, ControlType, Recipient},
-    IoAction,
+    MaybeFuture,
 };
 
 fn main() {

--- a/examples/bulk.rs
+++ b/examples/bulk.rs
@@ -1,17 +1,18 @@
 use futures_lite::future::block_on;
-use nusb::transfer::RequestBuffer;
+use nusb::{transfer::RequestBuffer, IoAction};
 
 fn main() {
     env_logger::init();
     let di = nusb::list_devices()
+        .wait()
         .unwrap()
         .find(|d| d.vendor_id() == 0x59e3 && d.product_id() == 0x0a23)
         .expect("device should be connected");
 
     println!("Device info: {di:?}");
 
-    let device = di.open().unwrap();
-    let interface = device.claim_interface(0).unwrap();
+    let device = di.open().wait().unwrap();
+    let interface = device.claim_interface(0).wait().unwrap();
 
     block_on(interface.bulk_out(0x02, Vec::from([1, 2, 3, 4, 5])))
         .into_result()

--- a/examples/bulk.rs
+++ b/examples/bulk.rs
@@ -1,5 +1,5 @@
 use futures_lite::future::block_on;
-use nusb::{transfer::RequestBuffer, IoAction};
+use nusb::{transfer::RequestBuffer, MaybeFuture};
 
 fn main() {
     env_logger::init();

--- a/examples/buses.rs
+++ b/examples/buses.rs
@@ -1,6 +1,8 @@
+use nusb::IoAction;
+
 fn main() {
     env_logger::init();
-    for dev in nusb::list_buses().unwrap() {
+    for dev in nusb::list_buses().wait().unwrap() {
         println!("{:#?}", dev);
     }
 }

--- a/examples/buses.rs
+++ b/examples/buses.rs
@@ -1,4 +1,4 @@
-use nusb::IoAction;
+use nusb::MaybeFuture;
 
 fn main() {
     env_logger::init();

--- a/examples/control.rs
+++ b/examples/control.rs
@@ -1,7 +1,7 @@
 use futures_lite::future::block_on;
 use nusb::{
     transfer::{ControlIn, ControlOut, ControlType, Recipient},
-    IoAction,
+    MaybeFuture,
 };
 
 fn main() {

--- a/examples/control.rs
+++ b/examples/control.rs
@@ -1,16 +1,20 @@
 use futures_lite::future::block_on;
-use nusb::transfer::{ControlIn, ControlOut, ControlType, Recipient};
+use nusb::{
+    transfer::{ControlIn, ControlOut, ControlType, Recipient},
+    IoAction,
+};
 
 fn main() {
     env_logger::init();
     let di = nusb::list_devices()
+        .wait()
         .unwrap()
         .find(|d| d.vendor_id() == 0x59e3 && d.product_id() == 0x0a23)
         .expect("device should be connected");
 
     println!("Device info: {di:?}");
 
-    let device = di.open().unwrap();
+    let device = di.open().wait().unwrap();
 
     // Linux can make control transfers without claiming an interface
     #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -37,7 +41,7 @@ fn main() {
     }
 
     // but we also provide an API on the `Interface` to support Windows
-    let interface = device.claim_interface(0).unwrap();
+    let interface = device.claim_interface(0).wait().unwrap();
 
     let result = block_on(interface.control_out(ControlOut {
         control_type: ControlType::Vendor,

--- a/examples/descriptors.rs
+++ b/examples/descriptors.rs
@@ -1,4 +1,4 @@
-use nusb::{DeviceInfo, IoAction};
+use nusb::{DeviceInfo, MaybeFuture};
 
 fn main() {
     env_logger::init();

--- a/examples/descriptors.rs
+++ b/examples/descriptors.rs
@@ -1,8 +1,8 @@
-use nusb::DeviceInfo;
+use nusb::{DeviceInfo, IoAction};
 
 fn main() {
     env_logger::init();
-    for dev in nusb::list_devices().unwrap() {
+    for dev in nusb::list_devices().wait().unwrap() {
         inspect_device(dev);
     }
 }
@@ -17,7 +17,7 @@ fn inspect_device(dev: DeviceInfo) {
         dev.manufacturer_string().unwrap_or(""),
         dev.product_string().unwrap_or("")
     );
-    let dev = match dev.open() {
+    let dev = match dev.open().wait() {
         Ok(dev) => dev,
         Err(e) => {
             println!("Failed to open device: {}", e);

--- a/examples/detach.rs
+++ b/examples/detach.rs
@@ -1,13 +1,16 @@
 //! Detach the kernel driver for an FTDI device and then reattach it.
 use std::{thread::sleep, time::Duration};
+
+use nusb::IoAction;
 fn main() {
     env_logger::init();
     let di = nusb::list_devices()
+        .wait()
         .unwrap()
         .find(|d| d.vendor_id() == 0x0403 && d.product_id() == 0x6001)
         .expect("device should be connected");
 
-    let device = di.open().unwrap();
+    let device = di.open().wait().unwrap();
     device.detach_kernel_driver(0).unwrap();
     sleep(Duration::from_secs(10));
     device.attach_kernel_driver(0).unwrap();

--- a/examples/detach.rs
+++ b/examples/detach.rs
@@ -1,7 +1,7 @@
 //! Detach the kernel driver for an FTDI device and then reattach it.
 use std::{thread::sleep, time::Duration};
 
-use nusb::IoAction;
+use nusb::MaybeFuture;
 fn main() {
     env_logger::init();
     let di = nusb::list_devices()

--- a/examples/detach_claim.rs
+++ b/examples/detach_claim.rs
@@ -1,15 +1,18 @@
 //! Detach the kernel driver for an FTDI device, claim the USB interface, and
 //! then reattach it.
 use std::{thread::sleep, time::Duration};
+
+use nusb::IoAction;
 fn main() {
     env_logger::init();
     let di = nusb::list_devices()
+        .wait()
         .unwrap()
         .find(|d| d.vendor_id() == 0x0403 && d.product_id() == 0x6010)
         .expect("device should be connected");
 
-    let device = di.open().unwrap();
-    let interface = device.detach_and_claim_interface(0).unwrap();
+    let device = di.open().wait().unwrap();
+    let interface = device.detach_and_claim_interface(0).wait().unwrap();
     sleep(Duration::from_secs(1));
     drop(interface);
 }

--- a/examples/detach_claim.rs
+++ b/examples/detach_claim.rs
@@ -2,7 +2,7 @@
 //! then reattach it.
 use std::{thread::sleep, time::Duration};
 
-use nusb::IoAction;
+use nusb::MaybeFuture;
 fn main() {
     env_logger::init();
     let di = nusb::list_devices()

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -1,6 +1,8 @@
+use nusb::IoAction;
+
 fn main() {
     env_logger::init();
-    for dev in nusb::list_devices().unwrap() {
+    for dev in nusb::list_devices().wait().unwrap() {
         println!("{:#?}", dev);
     }
 }

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -1,4 +1,4 @@
-use nusb::IoAction;
+use nusb::MaybeFuture;
 
 fn main() {
     env_logger::init();

--- a/examples/string_descriptors.rs
+++ b/examples/string_descriptors.rs
@@ -1,10 +1,10 @@
 use std::time::Duration;
 
-use nusb::{descriptors::language_id::US_ENGLISH, DeviceInfo};
+use nusb::{descriptors::language_id::US_ENGLISH, DeviceInfo, IoAction};
 
 fn main() {
     env_logger::init();
-    for dev in nusb::list_devices().unwrap() {
+    for dev in nusb::list_devices().wait().unwrap() {
         inspect_device(dev);
     }
 }
@@ -19,7 +19,7 @@ fn inspect_device(dev: DeviceInfo) {
         dev.manufacturer_string().unwrap_or(""),
         dev.product_string().unwrap_or("")
     );
-    let dev = match dev.open() {
+    let dev = match dev.open().wait() {
         Ok(dev) => dev,
         Err(e) => {
             println!("Failed to open device: {}", e);

--- a/examples/string_descriptors.rs
+++ b/examples/string_descriptors.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use nusb::{descriptors::language_id::US_ENGLISH, DeviceInfo, IoAction};
+use nusb::{descriptors::language_id::US_ENGLISH, DeviceInfo, MaybeFuture};
 
 fn main() {
     env_logger::init();

--- a/src/enumeration.rs
+++ b/src/enumeration.rs
@@ -4,7 +4,7 @@ use std::ffi::{OsStr, OsString};
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use crate::platform::SysfsPath;
 
-use crate::{Device, Error, IoAction};
+use crate::{Device, Error, MaybeFuture};
 
 /// Opaque device identifier
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
@@ -277,7 +277,7 @@ impl DeviceInfo {
     }
 
     /// Open the device
-    pub fn open(&self) -> impl IoAction<Output = Result<Device, Error>> {
+    pub fn open(&self) -> impl MaybeFuture<Output = Result<Device, Error>> {
         Device::open(self)
     }
 }

--- a/src/enumeration.rs
+++ b/src/enumeration.rs
@@ -4,7 +4,7 @@ use std::ffi::{OsStr, OsString};
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use crate::platform::SysfsPath;
 
-use crate::{Device, Error};
+use crate::{Device, Error, IoAction};
 
 /// Opaque device identifier
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
@@ -277,7 +277,7 @@ impl DeviceInfo {
     }
 
     /// Open the device
-    pub fn open(&self) -> Result<Device, Error> {
+    pub fn open(&self) -> impl IoAction<Output = Result<Device, Error>> {
         Device::open(self)
     }
 }

--- a/src/ioaction.rs
+++ b/src/ioaction.rs
@@ -1,0 +1,75 @@
+use std::future::IntoFuture;
+
+/// IO that may be performed synchronously or asynchronously.
+///
+/// An `IOAction` can be run asynchronously with `.await`, or
+/// run synchronously (blocking the current thread) with `.wait()`.
+pub trait IoAction: IntoFuture {
+    /// Block waiting for the action to complete
+    #[cfg(not(target_arch = "wasm32"))]
+    fn wait(self) -> Self::Output;
+}
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "windows",
+    target_os = "macos"
+))]
+pub mod blocking {
+    use super::IoAction;
+    use std::future::IntoFuture;
+
+    /// Wrapper that invokes a FnOnce on a background thread when
+    /// called asynchronously, or directly when called synchronously.
+    pub struct Blocking<F> {
+        f: F,
+    }
+
+    impl<F> Blocking<F> {
+        pub fn new(f: F) -> Self {
+            Self { f }
+        }
+    }
+
+    impl<F, R> IntoFuture for Blocking<F>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        type Output = R;
+
+        type IntoFuture = blocking::Task<R, ()>;
+
+        fn into_future(self) -> Self::IntoFuture {
+            blocking::unblock(self.f)
+        }
+    }
+
+    impl<F, R> IoAction for Blocking<F>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        fn wait(self) -> R {
+            (self.f)()
+        }
+    }
+}
+
+pub(crate) struct Ready<T>(pub(crate) T);
+
+impl<T> IntoFuture for Ready<T> {
+    type Output = T;
+    type IntoFuture = std::future::Ready<T>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        std::future::ready(self.0)
+    }
+}
+
+impl<T> IoAction for Ready<T> {
+    fn wait(self) -> Self::Output {
+        self.0
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,8 +129,8 @@ pub mod transfer;
 
 pub mod hotplug;
 
-mod ioaction;
-pub use ioaction::IoAction;
+mod maybe_future;
+pub use maybe_future::MaybeFuture;
 
 /// OS error returned from operations other than transfers.
 pub type Error = io::Error;
@@ -140,12 +140,13 @@ pub type Error = io::Error;
 /// ### Example
 ///
 /// ```no_run
-/// use nusb::{self, IoAction};
+/// use nusb::{self, MaybeFuture};
 /// let device = nusb::list_devices().wait().unwrap()
 ///     .find(|dev| dev.vendor_id() == 0xAAAA && dev.product_id() == 0xBBBB)
 ///     .expect("device not connected");
 /// ```
-pub fn list_devices() -> impl IoAction<Output = Result<impl Iterator<Item = DeviceInfo>, Error>> {
+pub fn list_devices() -> impl MaybeFuture<Output = Result<impl Iterator<Item = DeviceInfo>, Error>>
+{
     platform::list_devices()
 }
 
@@ -157,7 +158,7 @@ pub fn list_devices() -> impl IoAction<Output = Result<impl Iterator<Item = Devi
 ///
 /// ```no_run
 /// use std::collections::HashMap;
-/// use nusb::IoAction;
+/// use nusb::MaybeFuture;
 ///
 /// let devices = nusb::list_devices().wait().unwrap().collect::<Vec<_>>();
 /// let buses: HashMap<String, (nusb::BusInfo, Vec::<nusb::DeviceInfo>)> = nusb::list_buses().wait().unwrap()
@@ -171,7 +172,7 @@ pub fn list_devices() -> impl IoAction<Output = Result<impl Iterator<Item = Devi
 /// ### Platform-specific notes
 /// * On Linux, the abstraction of the "bus" is a phony device known as the root hub. This device is available at bus.root_hub()
 /// * On Android, this will only work on rooted devices due to sysfs path usage
-pub fn list_buses() -> impl IoAction<Output = Result<impl Iterator<Item = BusInfo>, Error>> {
+pub fn list_buses() -> impl MaybeFuture<Output = Result<impl Iterator<Item = BusInfo>, Error>> {
     platform::list_buses()
 }
 
@@ -188,7 +189,7 @@ pub fn list_buses() -> impl IoAction<Output = Result<impl Iterator<Item = BusInf
 ///
 /// ```no_run
 /// use std::collections::HashMap;
-/// use nusb::{IoAction, DeviceInfo, DeviceId, hotplug::HotplugEvent};
+/// use nusb::{MaybeFuture, DeviceInfo, DeviceId, hotplug::HotplugEvent};
 /// let watch = nusb::watch_devices().unwrap();
 /// let mut devices: HashMap<DeviceId, DeviceInfo> = nusb::list_devices().wait().unwrap()
 ///     .map(|d| (d.id(), d)).collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,9 @@ pub mod transfer;
 
 pub mod hotplug;
 
+mod ioaction;
+pub use ioaction::IoAction;
+
 /// OS error returned from operations other than transfers.
 pub type Error = io::Error;
 
@@ -137,12 +140,12 @@ pub type Error = io::Error;
 /// ### Example
 ///
 /// ```no_run
-/// use nusb;
-/// let device = nusb::list_devices().unwrap()
+/// use nusb::{self, IoAction};
+/// let device = nusb::list_devices().wait().unwrap()
 ///     .find(|dev| dev.vendor_id() == 0xAAAA && dev.product_id() == 0xBBBB)
 ///     .expect("device not connected");
 /// ```
-pub fn list_devices() -> Result<impl Iterator<Item = DeviceInfo>, Error> {
+pub fn list_devices() -> impl IoAction<Output = Result<impl Iterator<Item = DeviceInfo>, Error>> {
     platform::list_devices()
 }
 
@@ -154,9 +157,10 @@ pub fn list_devices() -> Result<impl Iterator<Item = DeviceInfo>, Error> {
 ///
 /// ```no_run
 /// use std::collections::HashMap;
+/// use nusb::IoAction;
 ///
-/// let devices = nusb::list_devices().unwrap().collect::<Vec<_>>();
-/// let buses: HashMap<String, (nusb::BusInfo, Vec::<nusb::DeviceInfo>)> = nusb::list_buses().unwrap()
+/// let devices = nusb::list_devices().wait().unwrap().collect::<Vec<_>>();
+/// let buses: HashMap<String, (nusb::BusInfo, Vec::<nusb::DeviceInfo>)> = nusb::list_buses().wait().unwrap()
 ///     .map(|bus| {
 ///         let bus_id = bus.bus_id().to_owned();
 ///         (bus.bus_id().to_owned(), (bus, devices.clone().into_iter().filter(|dev| dev.bus_id() == bus_id).collect()))
@@ -167,7 +171,7 @@ pub fn list_devices() -> Result<impl Iterator<Item = DeviceInfo>, Error> {
 /// ### Platform-specific notes
 /// * On Linux, the abstraction of the "bus" is a phony device known as the root hub. This device is available at bus.root_hub()
 /// * On Android, this will only work on rooted devices due to sysfs path usage
-pub fn list_buses() -> Result<impl Iterator<Item = BusInfo>, Error> {
+pub fn list_buses() -> impl IoAction<Output = Result<impl Iterator<Item = BusInfo>, Error>> {
     platform::list_buses()
 }
 
@@ -184,9 +188,9 @@ pub fn list_buses() -> Result<impl Iterator<Item = BusInfo>, Error> {
 ///
 /// ```no_run
 /// use std::collections::HashMap;
-/// use nusb::{DeviceInfo, DeviceId, hotplug::HotplugEvent};
+/// use nusb::{IoAction, DeviceInfo, DeviceId, hotplug::HotplugEvent};
 /// let watch = nusb::watch_devices().unwrap();
-/// let mut devices: HashMap<DeviceId, DeviceInfo> = nusb::list_devices().unwrap()
+/// let mut devices: HashMap<DeviceId, DeviceInfo> = nusb::list_devices().wait().unwrap()
 ///     .map(|d| (d.id(), d)).collect();
 /// for event in futures_lite::stream::block_on(watch) {
 ///     match event {

--- a/src/maybe_future.rs
+++ b/src/maybe_future.rs
@@ -2,9 +2,9 @@ use std::future::IntoFuture;
 
 /// IO that may be performed synchronously or asynchronously.
 ///
-/// An `IOAction` can be run asynchronously with `.await`, or
+/// A `MaybeFuture` can be run asynchronously with `.await`, or
 /// run synchronously (blocking the current thread) with `.wait()`.
-pub trait IoAction: IntoFuture {
+pub trait MaybeFuture: IntoFuture {
     /// Block waiting for the action to complete
     #[cfg(not(target_arch = "wasm32"))]
     fn wait(self) -> Self::Output;
@@ -17,7 +17,7 @@ pub trait IoAction: IntoFuture {
     target_os = "macos"
 ))]
 pub mod blocking {
-    use super::IoAction;
+    use super::MaybeFuture;
     use std::future::IntoFuture;
 
     /// Wrapper that invokes a FnOnce on a background thread when
@@ -46,7 +46,7 @@ pub mod blocking {
         }
     }
 
-    impl<F, R> IoAction for Blocking<F>
+    impl<F, R> MaybeFuture for Blocking<F>
     where
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
@@ -68,7 +68,7 @@ impl<T> IntoFuture for Ready<T> {
     }
 }
 
-impl<T> IoAction for Ready<T> {
+impl<T> MaybeFuture for Ready<T> {
     fn wait(self) -> Self::Output {
         self.0
     }

--- a/src/platform/linux_usbfs/enumeration.rs
+++ b/src/platform/linux_usbfs/enumeration.rs
@@ -8,8 +8,7 @@ use log::debug;
 use log::warn;
 
 use crate::enumeration::InterfaceInfo;
-use crate::ioaction::Ready;
-use crate::IoAction;
+use crate::maybe_future::{MaybeFuture, Ready};
 use crate::{BusInfo, DeviceInfo, Error, Speed, UsbControllerType};
 
 #[derive(Debug, Clone)]
@@ -121,7 +120,8 @@ impl FromHexStr for u16 {
 
 const SYSFS_USB_PREFIX: &'static str = "/sys/bus/usb/devices/";
 
-pub fn list_devices() -> impl IoAction<Output = Result<impl Iterator<Item = DeviceInfo>, Error>> {
+pub fn list_devices() -> impl MaybeFuture<Output = Result<impl Iterator<Item = DeviceInfo>, Error>>
+{
     Ready((|| {
         Ok(fs::read_dir(SYSFS_USB_PREFIX)?.flat_map(|entry| {
             let path = entry.ok()?.path();
@@ -162,7 +162,7 @@ pub fn list_root_hubs() -> Result<impl Iterator<Item = DeviceInfo>, Error> {
     }))
 }
 
-pub fn list_buses() -> impl IoAction<Output = Result<impl Iterator<Item = BusInfo>, Error>> {
+pub fn list_buses() -> impl MaybeFuture<Output = Result<impl Iterator<Item = BusInfo>, Error>> {
     Ready((|| {
         Ok(list_root_hubs()?.filter_map(|rh| {
             // get the parent by following the absolute symlink; root hub in /bus/usb is a symlink to a dir in parent bus

--- a/src/platform/macos_iokit/enumeration.rs
+++ b/src/platform/macos_iokit/enumeration.rs
@@ -16,8 +16,9 @@ use io_kit_sys::{
 use log::debug;
 
 use crate::{
-    descriptors::DeviceDescriptor, ioaction::Ready, BusInfo, DeviceInfo, Error, InterfaceInfo,
-    IoAction, Speed, UsbControllerType,
+    descriptors::DeviceDescriptor,
+    maybe_future::{MaybeFuture, Ready},
+    BusInfo, DeviceInfo, Error, InterfaceInfo, Speed, UsbControllerType,
 };
 
 use super::iokit::{IoService, IoServiceIterator};
@@ -79,11 +80,12 @@ fn usb_controller_service_iter(
     }
 }
 
-pub fn list_devices() -> impl IoAction<Output = Result<impl Iterator<Item = DeviceInfo>, Error>> {
+pub fn list_devices() -> impl MaybeFuture<Output = Result<impl Iterator<Item = DeviceInfo>, Error>>
+{
     Ready(usb_service_iter().map(|i| i.filter_map(probe_device)))
 }
 
-pub fn list_buses() -> impl IoAction<Output = Result<impl Iterator<Item = BusInfo>, Error>> {
+pub fn list_buses() -> impl MaybeFuture<Output = Result<impl Iterator<Item = BusInfo>, Error>> {
     // Chain all the HCI types into one iterator
     // A bit of a hack, could maybe probe IOPCIDevice and filter on children with IOClass.starts_with("AppleUSB")
     Ready(Ok([

--- a/src/platform/macos_iokit/enumeration.rs
+++ b/src/platform/macos_iokit/enumeration.rs
@@ -16,8 +16,8 @@ use io_kit_sys::{
 use log::debug;
 
 use crate::{
-    descriptors::DeviceDescriptor, BusInfo, DeviceInfo, Error, InterfaceInfo, Speed,
-    UsbControllerType,
+    descriptors::DeviceDescriptor, ioaction::Ready, BusInfo, DeviceInfo, Error, InterfaceInfo,
+    IoAction, Speed, UsbControllerType,
 };
 
 use super::iokit::{IoService, IoServiceIterator};
@@ -79,14 +79,14 @@ fn usb_controller_service_iter(
     }
 }
 
-pub fn list_devices() -> Result<impl Iterator<Item = DeviceInfo>, Error> {
-    Ok(usb_service_iter()?.filter_map(probe_device))
+pub fn list_devices() -> impl IoAction<Output = Result<impl Iterator<Item = DeviceInfo>, Error>> {
+    Ready(usb_service_iter().map(|i| i.filter_map(probe_device)))
 }
 
-pub fn list_buses() -> Result<impl Iterator<Item = BusInfo>, Error> {
+pub fn list_buses() -> impl IoAction<Output = Result<impl Iterator<Item = BusInfo>, Error>> {
     // Chain all the HCI types into one iterator
     // A bit of a hack, could maybe probe IOPCIDevice and filter on children with IOClass.starts_with("AppleUSB")
-    Ok([
+    Ready(Ok([
         UsbControllerType::XHCI,
         UsbControllerType::EHCI,
         UsbControllerType::OHCI,
@@ -97,7 +97,7 @@ pub fn list_buses() -> Result<impl Iterator<Item = BusInfo>, Error> {
         usb_controller_service_iter(hci_type)
             .map(|iter| iter.flat_map(|dev| probe_bus(dev, hci_type)))
     })
-    .flatten())
+    .flatten()))
 }
 
 pub(crate) fn service_by_registry_id(registry_id: u64) -> Result<IoService, Error> {

--- a/src/platform/windows_winusb/device.rs
+++ b/src/platform/windows_winusb/device.rs
@@ -27,8 +27,9 @@ use crate::{
         validate_config_descriptor, DeviceDescriptor, DESCRIPTOR_LEN_DEVICE,
         DESCRIPTOR_TYPE_CONFIGURATION,
     },
+    ioaction::{blocking::Blocking, Ready},
     transfer::{Control, Direction, EndpointType, Recipient, TransferError, TransferHandle},
-    DeviceInfo, Error, Speed,
+    DeviceInfo, Error, IoAction, Speed,
 };
 
 use super::{
@@ -50,45 +51,51 @@ pub(crate) struct WindowsDevice {
 }
 
 impl WindowsDevice {
-    pub(crate) fn from_device_info(d: &DeviceInfo) -> Result<Arc<WindowsDevice>, Error> {
-        debug!("Creating device for {:?}", d.instance_id);
+    pub(crate) fn from_device_info(
+        d: &DeviceInfo,
+    ) -> impl IoAction<Output = Result<crate::Device, Error>> {
+        let instance_id = d.instance_id.clone();
+        let devinst = d.devinst;
+        Blocking::new(move || {
+            debug!("Creating device for {:?}", instance_id);
 
-        // Look up the device again in case the DeviceInfo is stale. In
-        // particular, don't trust its `port_number` because another device
-        // might now be connected to that port, and we'd get its descriptors
-        // instead.
-        let hub_port = HubPort::by_child_devinst(d.devinst)?;
-        let connection_info = hub_port.get_info()?;
+            // Look up the device again in case the DeviceInfo is stale. In
+            // particular, don't trust its `port_number` because another device
+            // might now be connected to that port, and we'd get its descriptors
+            // instead.
+            let hub_port = HubPort::by_child_devinst(devinst)?;
+            let connection_info = hub_port.get_info()?;
 
-        // Safety: Windows API struct is repr(C), packed, and we're assuming Windows is little-endian
-        let device_descriptor = unsafe {
-            DeviceDescriptor::new(&transmute::<_, [u8; DESCRIPTOR_LEN_DEVICE as usize]>(
-                connection_info.device_desc,
-            ))
-        };
+            // Safety: Windows API struct is repr(C), packed, and we're assuming Windows is little-endian
+            let device_descriptor = unsafe {
+                DeviceDescriptor::new(&transmute::<_, [u8; DESCRIPTOR_LEN_DEVICE as usize]>(
+                    connection_info.device_desc,
+                ))
+            };
 
-        let num_configurations = connection_info.device_desc.bNumConfigurations;
-        let config_descriptors = (0..num_configurations)
-            .flat_map(|i| {
-                let res = hub_port.get_descriptor(DESCRIPTOR_TYPE_CONFIGURATION, i, 0);
-                match res {
-                    Ok(v) => validate_config_descriptor(&v[..]).map(|_| v),
-                    Err(e) => {
-                        error!("Failed to read config descriptor {}: {}", i, e);
-                        None
+            let num_configurations = connection_info.device_desc.bNumConfigurations;
+            let config_descriptors = (0..num_configurations)
+                .flat_map(|i| {
+                    let res = hub_port.get_descriptor(DESCRIPTOR_TYPE_CONFIGURATION, i, 0);
+                    match res {
+                        Ok(v) => validate_config_descriptor(&v[..]).map(|_| v),
+                        Err(e) => {
+                            error!("Failed to read config descriptor {}: {}", i, e);
+                            None
+                        }
                     }
-                }
-            })
-            .collect();
+                })
+                .collect();
 
-        Ok(Arc::new(WindowsDevice {
-            device_descriptor,
-            config_descriptors,
-            speed: connection_info.speed,
-            active_config: connection_info.active_config,
-            devinst: d.devinst,
-            handles: Mutex::new(BTreeMap::new()),
-        }))
+            Ok(crate::Device::wrap(Arc::new(WindowsDevice {
+                device_descriptor,
+                config_descriptors,
+                speed: connection_info.speed,
+                active_config: connection_info.active_config,
+                devinst: devinst,
+                handles: Mutex::new(BTreeMap::new()),
+            })))
+        })
     }
 
     pub(crate) fn device_descriptor(&self) -> DeviceDescriptor {
@@ -107,11 +114,14 @@ impl WindowsDevice {
         self.config_descriptors.iter().map(|d| &d[..])
     }
 
-    pub(crate) fn set_configuration(&self, _configuration: u8) -> Result<(), Error> {
-        Err(io::Error::new(
+    pub(crate) fn set_configuration(
+        &self,
+        _configuration: u8,
+    ) -> impl IoAction<Output = Result<(), Error>> {
+        Ready(Err(io::Error::new(
             ErrorKind::Unsupported,
             "set_configuration not supported by WinUSB",
-        ))
+        )))
     }
 
     pub(crate) fn get_descriptor(
@@ -123,14 +133,24 @@ impl WindowsDevice {
         HubPort::by_child_devinst(self.devinst)?.get_descriptor(desc_type, desc_index, language_id)
     }
 
-    pub(crate) fn reset(&self) -> Result<(), Error> {
-        Err(io::Error::new(
+    pub(crate) fn reset(&self) -> impl IoAction<Output = Result<(), Error>> {
+        Ready(Err(io::Error::new(
             ErrorKind::Unsupported,
             "reset not supported by WinUSB",
-        ))
+        )))
     }
 
     pub(crate) fn claim_interface(
+        self: Arc<Self>,
+        interface_number: u8,
+    ) -> impl IoAction<Output = Result<crate::Interface, Error>> {
+        Blocking::new(move || {
+            self.claim_interface_blocking(interface_number)
+                .map(crate::Interface::wrap)
+        })
+    }
+
+    fn claim_interface_blocking(
         self: &Arc<Self>,
         interface_number: u8,
     ) -> Result<Arc<WindowsInterface>, Error> {
@@ -177,9 +197,9 @@ impl WindowsDevice {
     }
 
     pub(crate) fn detach_and_claim_interface(
-        self: &Arc<Self>,
+        self: Arc<Self>,
         interface: u8,
-    ) -> Result<Arc<WindowsInterface>, Error> {
+    ) -> impl IoAction<Output = Result<crate::Interface, Error>> {
         self.claim_interface(interface)
     }
 }
@@ -478,26 +498,31 @@ impl WindowsInterface {
         }
     }
 
-    pub fn set_alt_setting(&self, alt_setting: u8) -> Result<(), Error> {
-        unsafe {
+    pub fn set_alt_setting(
+        self: Arc<Self>,
+        alt_setting: u8,
+    ) -> impl IoAction<Output = Result<(), Error>> {
+        Blocking::new(move || unsafe {
             let r = WinUsb_SetCurrentAlternateSetting(self.winusb_handle, alt_setting.into());
             if r == TRUE {
                 Ok(())
             } else {
                 Err(io::Error::last_os_error())
             }
-        }
+        })
     }
 
-    pub fn clear_halt(&self, endpoint: u8) -> Result<(), Error> {
-        debug!("Clear halt, endpoint {endpoint:02x}");
-        unsafe {
-            let r = WinUsb_ResetPipe(self.winusb_handle, endpoint);
-            if r == TRUE {
-                Ok(())
-            } else {
-                Err(io::Error::last_os_error())
+    pub fn clear_halt(self: Arc<Self>, endpoint: u8) -> impl IoAction<Output = Result<(), Error>> {
+        Blocking::new(move || {
+            debug!("Clear halt, endpoint {endpoint:02x}");
+            unsafe {
+                let r = WinUsb_ResetPipe(self.winusb_handle, endpoint);
+                if r == TRUE {
+                    Ok(())
+                } else {
+                    Err(io::Error::last_os_error())
+                }
             }
-        }
+        })
     }
 }

--- a/src/platform/windows_winusb/enumeration.rs
+++ b/src/platform/windows_winusb/enumeration.rs
@@ -18,8 +18,8 @@ use crate::{
         decode_string_descriptor, language_id::US_ENGLISH, validate_config_descriptor,
         Configuration, DESCRIPTOR_TYPE_CONFIGURATION, DESCRIPTOR_TYPE_STRING,
     },
-    ioaction::blocking::Blocking,
-    BusInfo, DeviceInfo, Error, InterfaceInfo, IoAction, UsbControllerType,
+    maybe_future::{blocking::Blocking, MaybeFuture},
+    BusInfo, DeviceInfo, Error, InterfaceInfo, UsbControllerType,
 };
 
 use super::{
@@ -28,7 +28,8 @@ use super::{
     util::WCString,
 };
 
-pub fn list_devices() -> impl IoAction<Output = Result<impl Iterator<Item = DeviceInfo>, Error>> {
+pub fn list_devices() -> impl MaybeFuture<Output = Result<impl Iterator<Item = DeviceInfo>, Error>>
+{
     Blocking::new(|| {
         let devs: Vec<DeviceInfo> = cfgmgr32::list_interfaces(GUID_DEVINTERFACE_USB_DEVICE, None)
             // get USB_HUB devices as well, like other platforms. ROOT_HUBs will be dropped by probe_device
@@ -42,7 +43,7 @@ pub fn list_devices() -> impl IoAction<Output = Result<impl Iterator<Item = Devi
     })
 }
 
-pub fn list_buses() -> impl IoAction<Output = Result<impl Iterator<Item = BusInfo>, Error>> {
+pub fn list_buses() -> impl MaybeFuture<Output = Result<impl Iterator<Item = BusInfo>, Error>> {
     Blocking::new(|| {
         let devs: Vec<BusInfo> = cfgmgr32::list_interfaces(GUID_DEVINTERFACE_USB_HUB, None)
             .iter()

--- a/src/platform/windows_winusb/enumeration.rs
+++ b/src/platform/windows_winusb/enumeration.rs
@@ -18,7 +18,8 @@ use crate::{
         decode_string_descriptor, language_id::US_ENGLISH, validate_config_descriptor,
         Configuration, DESCRIPTOR_TYPE_CONFIGURATION, DESCRIPTOR_TYPE_STRING,
     },
-    BusInfo, DeviceInfo, Error, InterfaceInfo, UsbControllerType,
+    ioaction::blocking::Blocking,
+    BusInfo, DeviceInfo, Error, InterfaceInfo, IoAction, UsbControllerType,
 };
 
 use super::{
@@ -27,26 +28,30 @@ use super::{
     util::WCString,
 };
 
-pub fn list_devices() -> Result<impl Iterator<Item = DeviceInfo>, Error> {
-    let devs: Vec<DeviceInfo> = cfgmgr32::list_interfaces(GUID_DEVINTERFACE_USB_DEVICE, None)
-        // get USB_HUB devices as well, like other platforms. ROOT_HUBs will be dropped by probe_device
-        .iter()
-        .chain(cfgmgr32::list_interfaces(GUID_DEVINTERFACE_USB_HUB, None).iter())
-        .flat_map(|i| get_device_interface_property::<WCString>(i, DEVPKEY_Device_InstanceId))
-        .flat_map(|d| DevInst::from_instance_id(&d))
-        .flat_map(probe_device)
-        .collect();
-    Ok(devs.into_iter())
+pub fn list_devices() -> impl IoAction<Output = Result<impl Iterator<Item = DeviceInfo>, Error>> {
+    Blocking::new(|| {
+        let devs: Vec<DeviceInfo> = cfgmgr32::list_interfaces(GUID_DEVINTERFACE_USB_DEVICE, None)
+            // get USB_HUB devices as well, like other platforms. ROOT_HUBs will be dropped by probe_device
+            .iter()
+            .chain(cfgmgr32::list_interfaces(GUID_DEVINTERFACE_USB_HUB, None).iter())
+            .flat_map(|i| get_device_interface_property::<WCString>(i, DEVPKEY_Device_InstanceId))
+            .flat_map(|d| DevInst::from_instance_id(&d))
+            .flat_map(probe_device)
+            .collect();
+        Ok(devs.into_iter())
+    })
 }
 
-pub fn list_buses() -> Result<impl Iterator<Item = BusInfo>, Error> {
-    let devs: Vec<BusInfo> = cfgmgr32::list_interfaces(GUID_DEVINTERFACE_USB_HUB, None)
-        .iter()
-        .flat_map(|i| get_device_interface_property::<WCString>(i, DEVPKEY_Device_InstanceId))
-        .flat_map(|d| DevInst::from_instance_id(&d))
-        .flat_map(probe_bus)
-        .collect();
-    Ok(devs.into_iter())
+pub fn list_buses() -> impl IoAction<Output = Result<impl Iterator<Item = BusInfo>, Error>> {
+    Blocking::new(|| {
+        let devs: Vec<BusInfo> = cfgmgr32::list_interfaces(GUID_DEVINTERFACE_USB_HUB, None)
+            .iter()
+            .flat_map(|i| get_device_interface_property::<WCString>(i, DEVPKEY_Device_InstanceId))
+            .flat_map(|d| DevInst::from_instance_id(&d))
+            .flat_map(probe_bus)
+            .collect();
+        Ok(devs.into_iter())
+    })
 }
 
 pub fn probe_device(devinst: DevInst) -> Option<DeviceInfo> {

--- a/src/transfer/queue.rs
+++ b/src/transfer/queue.rs
@@ -6,7 +6,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use crate::{platform, Error, IoAction};
+use crate::{platform, Error, MaybeFuture};
 
 use super::{Completion, EndpointType, PlatformSubmit, TransferHandle, TransferRequest};
 
@@ -52,7 +52,7 @@ use super::{Completion, EndpointType, PlatformSubmit, TransferHandle, TransferRe
 /// ```no_run
 /// use futures_lite::future::block_on;
 /// use nusb::transfer::RequestBuffer;
-/// # use nusb::IoAction;
+/// # use nusb::MaybeFuture;
 /// # let di = nusb::list_devices().wait().unwrap().next().unwrap();
 /// # let device = di.open().wait().unwrap();
 /// # let interface = device.claim_interface(0).wait().unwrap();
@@ -82,7 +82,7 @@ use super::{Completion, EndpointType, PlatformSubmit, TransferHandle, TransferRe
 /// ```no_run
 /// use std::mem;
 /// use futures_lite::future::block_on;
-/// # use nusb::IoAction;
+/// # use nusb::MaybeFuture;
 /// # let di = nusb::list_devices().wait().unwrap().next().unwrap();
 /// # let device = di.open().wait().unwrap();
 /// # let interface = device.claim_interface(0).wait().unwrap();
@@ -223,7 +223,7 @@ where
     /// the error and resume use of the endpoint.
     ///
     /// This should not be called when transfers are pending on the endpoint.
-    pub fn clear_halt(&mut self) -> impl IoAction<Output = Result<(), Error>> {
+    pub fn clear_halt(&mut self) -> impl MaybeFuture<Output = Result<(), Error>> {
         self.interface.clone().clear_halt(self.endpoint)
     }
 }

--- a/src/transfer/queue.rs
+++ b/src/transfer/queue.rs
@@ -6,7 +6,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use crate::{platform, Error};
+use crate::{platform, Error, IoAction};
 
 use super::{Completion, EndpointType, PlatformSubmit, TransferHandle, TransferRequest};
 
@@ -52,9 +52,10 @@ use super::{Completion, EndpointType, PlatformSubmit, TransferHandle, TransferRe
 /// ```no_run
 /// use futures_lite::future::block_on;
 /// use nusb::transfer::RequestBuffer;
-/// # let di = nusb::list_devices().unwrap().next().unwrap();
-/// # let device = di.open().unwrap();
-/// # let interface = device.claim_interface(0).unwrap();
+/// # use nusb::IoAction;
+/// # let di = nusb::list_devices().wait().unwrap().next().unwrap();
+/// # let device = di.open().wait().unwrap();
+/// # let interface = device.claim_interface(0).wait().unwrap();
 /// # fn handle_data(_: &[u8]) {}
 /// let mut queue = interface.bulk_in_queue(0x81);
 ///
@@ -81,9 +82,10 @@ use super::{Completion, EndpointType, PlatformSubmit, TransferHandle, TransferRe
 /// ```no_run
 /// use std::mem;
 /// use futures_lite::future::block_on;
-/// # let di = nusb::list_devices().unwrap().next().unwrap();
-/// # let device = di.open().unwrap();
-/// # let interface = device.claim_interface(0).unwrap();
+/// # use nusb::IoAction;
+/// # let di = nusb::list_devices().wait().unwrap().next().unwrap();
+/// # let device = di.open().wait().unwrap();
+/// # let interface = device.claim_interface(0).wait().unwrap();
 /// # fn fill_data(_: &mut Vec<u8>) {}
 /// # fn data_confirmed_sent(_: usize) {}
 /// let mut queue = interface.bulk_out_queue(0x02);
@@ -221,8 +223,8 @@ where
     /// the error and resume use of the endpoint.
     ///
     /// This should not be called when transfers are pending on the endpoint.
-    pub fn clear_halt(&mut self) -> Result<(), Error> {
-        self.interface.clear_halt(self.endpoint)
+    pub fn clear_halt(&mut self) -> impl IoAction<Output = Result<(), Error>> {
+        self.interface.clone().clear_halt(self.endpoint)
     }
 }
 


### PR DESCRIPTION
`DeviceInfo::open`, `Device::from_fd`, `Device::set_configuration`, `Device::reset`, `Interface::set_alt_setting`, `Interface::clear_halt` all perform IO but are currently blocking because the underlying OS APIs are blocking.

`list_devices`,`list_buses`, `Device::claim_interface` `Device::detach_and_claim_interface` theoretically don't perform IO, but are also included here because they need to be async on WebUSB.

The `IoAction` trait allows defering these actions to the thread pool from the `blocking` crate when used asynchronously with `.await` / `IntoFuture`, or directly runs the blocking syscall synchronously with a `.wait()` method.

Open question: Should the dependency on `blocking` be behind a cargo feature, and if unset, should `IoAction` not impl `IntoFuture` or should it return a dummy Future that runs synchronously?