### PR TITLE
Add support for getting device information from opened device on Linux

### DIFF
--- a/examples/descriptors.rs
+++ b/examples/descriptors.rs
@@ -25,6 +25,8 @@ fn inspect_device(dev: DeviceInfo) {
         }
     };
 
+    println!("{:#?}", dev.device_descriptor());
+
     match dev.active_configuration() {
         Ok(config) => println!("Active configuration is {}", config.configuration_value()),
         Err(e) => println!("Unknown active configuration: {e}"),

--- a/examples/descriptors.rs
+++ b/examples/descriptors.rs
@@ -27,6 +27,8 @@ fn inspect_device(dev: DeviceInfo) {
 
     println!("{:#?}", dev.device_descriptor());
 
+    println!("Speed: {:?}", dev.speed());
+
     match dev.active_configuration() {
         Ok(config) => println!("Active configuration is {}", config.configuration_value()),
         Err(e) => println!("Unknown active configuration: {e}"),

--- a/examples/string_descriptors.rs
+++ b/examples/string_descriptors.rs
@@ -29,14 +29,7 @@ fn inspect_device(dev: DeviceInfo) {
 
     let timeout = Duration::from_millis(100);
 
-    let dev_descriptor = dev.get_descriptor(0x01, 0, 0, timeout).unwrap();
-    if dev_descriptor.len() < 18
-        || dev_descriptor[0] as usize > dev_descriptor.len()
-        || dev_descriptor[1] != 0x01
-    {
-        println!("  Invalid device descriptor: {dev_descriptor:?}");
-        return;
-    }
+    let dev_descriptor = dev.device_descriptor();
 
     let languages: Vec<u16> = dev
         .get_string_descriptor_supported_languages(timeout)
@@ -46,20 +39,17 @@ fn inspect_device(dev: DeviceInfo) {
 
     let language = languages.first().copied().unwrap_or(US_ENGLISH);
 
-    let i_manufacturer = dev_descriptor[14];
-    if i_manufacturer != 0 {
+    if let Some(i_manufacturer) = dev_descriptor.manufacturer_string_index() {
         let s = dev.get_string_descriptor(i_manufacturer, language, timeout);
         println!("  Manufacturer({i_manufacturer}): {s:?}");
     }
 
-    let i_product = dev_descriptor[15];
-    if i_product != 0 {
+    if let Some(i_product) = dev_descriptor.product_string_index() {
         let s = dev.get_string_descriptor(i_product, language, timeout);
         println!("  Product({i_product}): {s:?}");
     }
 
-    let i_serial = dev_descriptor[16];
-    if i_serial != 0 {
+    if let Some(i_serial) = dev_descriptor.serial_number_string_index() {
         let s = dev.get_string_descriptor(i_serial, language, timeout);
         println!("  Serial({i_serial}): {s:?}");
     }

--- a/src/descriptors.rs
+++ b/src/descriptors.rs
@@ -231,6 +231,11 @@ impl DeviceDescriptor {
         Self(buf[0..DESCRIPTOR_LEN_DEVICE as usize].try_into().unwrap())
     }
 
+    /// Get the bytes of the descriptor.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
     pub(crate) fn from_fields(
         usb_version: u16,
         class: u8,

--- a/src/descriptors.rs
+++ b/src/descriptors.rs
@@ -181,6 +181,36 @@ macro_rules! descriptor_fields {
     }
 }
 
+/// Check whether the buffer contains a valid device descriptor.
+/// On success, it will return length of the descriptor, or returns `None`.
+pub(crate) fn validate_device_descriptor(buf: &[u8]) -> Option<usize> {
+    if buf.len() < DESCRIPTOR_LEN_DEVICE as usize {
+        if buf.len() != 0 {
+            warn!(
+                "device descriptor buffer is {} bytes, need {}",
+                buf.len(),
+                DESCRIPTOR_LEN_DEVICE
+            );
+        }
+        return None;
+    }
+
+    if buf[0] < DESCRIPTOR_LEN_DEVICE {
+        warn!("invalid device descriptor bLength");
+        return None;
+    }
+
+    if buf[1] != DESCRIPTOR_TYPE_DEVICE {
+        warn!(
+            "device bDescriptorType is {}, not a device descriptor",
+            buf[1]
+        );
+        return None;
+    }
+
+    return Some(buf[0] as usize);
+}
+
 /// Information about a USB device.
 #[derive(Clone)]
 pub struct DeviceDescriptor<'a>(&'a [u8]);

--- a/src/descriptors.rs
+++ b/src/descriptors.rs
@@ -302,14 +302,9 @@ descriptor_fields! {
         #[doc(alias = "bcdDevice")]
         pub fn device_version at 12 -> u16;
 
-        /// `iManufacturer` descriptor field: Index for manufacturer description string.
-        pub fn manufacturer_string_index at 14 -> u8;
-
-        /// `iProduct` descriptor field: Index for product description string.
-        pub fn product_string_index at 15 -> u8;
-
-        /// `iSerialNumber` descriptor field: Index for serial number string.
-        pub fn serial_number_string_index at 16 -> u8;
+        fn manufacturer_string_index_raw at 14 -> u8;
+        fn product_string_index_raw at 15 -> u8;
+        fn serial_number_string_index_raw at 16 -> u8;
 
         /// `bNumConfigurations` descriptor field: Number of configurations
         #[doc(alias = "bNumConfigurations")]
@@ -317,6 +312,22 @@ descriptor_fields! {
     }
 }
 
+impl DeviceDescriptor {
+    /// `iManufacturer` descriptor field: Index for manufacturer description string.
+    pub fn manufacturer_string_index(&self) -> Option<u8> {
+        Some(self.manufacturer_string_index_raw()).filter(|&i| i != 0)
+    }
+
+    /// `iProduct` descriptor field: Index for product description string.
+    pub fn product_string_index(&self) -> Option<u8> {
+        Some(self.product_string_index_raw()).filter(|&i| i != 0)
+    }
+
+    /// `iSerialNumber` descriptor field: Index for serial number string.
+    pub fn serial_number_string_index(&self) -> Option<u8> {
+        Some(self.serial_number_string_index_raw()).filter(|&i| i != 0)
+    }
+}
 impl Debug for DeviceDescriptor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DeviceDescriptor")
@@ -836,9 +847,9 @@ fn test_linux_root_hub() {
     assert_eq!(dev.vendor_id(), 0x1d6b);
     assert_eq!(dev.product_id(), 0x0002);
     assert_eq!(dev.device_version(), 0x0510);
-    assert_eq!(dev.manufacturer_string_index(), 3);
-    assert_eq!(dev.product_string_index(), 2);
-    assert_eq!(dev.serial_number_string_index(), 1);
+    assert_eq!(dev.manufacturer_string_index(), Some(3));
+    assert_eq!(dev.product_string_index(), Some(2));
+    assert_eq!(dev.serial_number_string_index(), Some(1));
     assert_eq!(dev.num_configurations(), 1);
 
     let c = Configuration(&[

--- a/src/descriptors.rs
+++ b/src/descriptors.rs
@@ -230,6 +230,42 @@ impl DeviceDescriptor {
         assert!(buf[1] == DESCRIPTOR_TYPE_DEVICE);
         Self(buf[0..DESCRIPTOR_LEN_DEVICE as usize].try_into().unwrap())
     }
+
+    pub(crate) fn from_fields(
+        usb_version: u16,
+        class: u8,
+        subclass: u8,
+        protocol: u8,
+        max_packet_size_0: u8,
+        vendor_id: u16,
+        product_id: u16,
+        device_version: u16,
+        manufacturer_string_index: u8,
+        product_string_index: u8,
+        serial_number_string_index: u8,
+        num_configurations: u8,
+    ) -> DeviceDescriptor {
+        DeviceDescriptor([
+            DESCRIPTOR_LEN_DEVICE,
+            DESCRIPTOR_TYPE_DEVICE,
+            usb_version.to_le_bytes()[0],
+            usb_version.to_le_bytes()[1],
+            class,
+            subclass,
+            protocol,
+            max_packet_size_0,
+            vendor_id.to_le_bytes()[0],
+            vendor_id.to_le_bytes()[1],
+            product_id.to_le_bytes()[0],
+            product_id.to_le_bytes()[1],
+            device_version.to_le_bytes()[0],
+            device_version.to_le_bytes()[1],
+            manufacturer_string_index,
+            product_string_index,
+            serial_number_string_index,
+            num_configurations,
+        ])
+    }
 }
 
 descriptor_fields! {

--- a/src/descriptors.rs
+++ b/src/descriptors.rs
@@ -183,6 +183,7 @@ macro_rules! descriptor_fields {
 
 /// Check whether the buffer contains a valid device descriptor.
 /// On success, it will return length of the descriptor, or returns `None`.
+#[allow(unused)]
 pub(crate) fn validate_device_descriptor(buf: &[u8]) -> Option<usize> {
     if buf.len() < DESCRIPTOR_LEN_DEVICE as usize {
         if buf.len() != 0 {
@@ -236,6 +237,7 @@ impl DeviceDescriptor {
         &self.0
     }
 
+    #[allow(unused)]
     pub(crate) fn from_fields(
         usb_version: u16,
         class: u8,
@@ -361,6 +363,7 @@ impl Debug for DeviceDescriptor {
     }
 }
 
+#[allow(unused)]
 pub(crate) fn validate_config_descriptor(buf: &[u8]) -> Option<usize> {
     if buf.len() < DESCRIPTOR_LEN_CONFIGURATION as usize {
         if buf.len() != 0 {
@@ -730,6 +733,7 @@ impl From<ActiveConfigurationError> for Error {
 }
 
 /// Split a chain of concatenated configuration descriptors by `wTotalLength`
+#[allow(unused)]
 pub(crate) fn parse_concatenated_config_descriptors(mut buf: &[u8]) -> impl Iterator<Item = &[u8]> {
     iter::from_fn(move || {
         let total_len = validate_config_descriptor(buf)?;

--- a/src/device.rs
+++ b/src/device.rs
@@ -97,21 +97,11 @@ impl Device {
     /// Get the device descriptor.
     ///
     /// This returns cached data and does not perform IO.
-    ///
-    /// ### Platform-specific notes
-    ///
-    /// * This is only supported on Linux and Windows at present.
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
     pub fn device_descriptor(&self) -> DeviceDescriptor {
         self.backend.device_descriptor()
     }
 
     /// Get device speed.
-    ///
-    /// ### Platform-specific notes
-    ///
-    /// * This is only supported on Linux and Windows at present.
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
     pub fn speed(&self) -> Option<Speed> {
         self.backend.speed()
     }

--- a/src/device.rs
+++ b/src/device.rs
@@ -9,7 +9,7 @@ use crate::{
         Control, ControlIn, ControlOut, EndpointType, Queue, RequestBuffer, TransferError,
         TransferFuture,
     },
-    DeviceInfo, Error,
+    DeviceInfo, Error, Speed,
 };
 use log::error;
 use std::{io::ErrorKind, sync::Arc, time::Duration};
@@ -357,6 +357,19 @@ impl Device {
     pub fn device_descriptor(&self) -> Option<DeviceDescriptor> {
         let buf = self.backend.descriptors();
         validate_device_descriptor(&buf).map(|len| DeviceDescriptor::new(&buf[0..len]))
+    }
+
+    /// Get device speed.
+    ///
+    /// On most platforms, the speed is stored by the OS, and calling this method should not
+    /// make any request to the device.
+    ///
+    /// ### Platform-specific notes
+    ///
+    /// * This is only supported on Linux at present.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub fn get_speed(&self) -> Result<Option<Speed>, Error> {
+        self.backend.get_speed()
     }
 }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -106,6 +106,16 @@ impl Device {
         self.backend.device_descriptor()
     }
 
+    /// Get device speed.
+    ///
+    /// ### Platform-specific notes
+    ///
+    /// * This is only supported on Linux at present.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub fn speed(&self) -> Option<Speed> {
+        self.backend.speed()
+    }
+
     /// Get information about the active configuration.
     ///
     /// This returns cached data and does not perform IO. However, it can fail if the
@@ -352,18 +362,6 @@ impl Device {
         let mut t = self.backend.make_control_transfer();
         t.submit::<ControlOut>(data);
         TransferFuture::new(t)
-    }
-    /// Get device speed.
-    ///
-    /// On most platforms, the speed is stored by the OS, and calling this method should not
-    /// make any request to the device.
-    ///
-    /// ### Platform-specific notes
-    ///
-    /// * This is only supported on Linux at present.
-    #[cfg(any(target_os = "linux", target_os = "android"))]
-    pub fn get_speed(&self) -> Result<Option<Speed>, Error> {
-        self.backend.get_speed()
     }
 }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -100,8 +100,8 @@ impl Device {
     ///
     /// ### Platform-specific notes
     ///
-    /// * This is only supported on Linux at present.
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    /// * This is only supported on Linux and Windows at present.
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
     pub fn device_descriptor(&self) -> DeviceDescriptor {
         self.backend.device_descriptor()
     }
@@ -110,8 +110,8 @@ impl Device {
     ///
     /// ### Platform-specific notes
     ///
-    /// * This is only supported on Linux at present.
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    /// * This is only supported on Linux and Windows at present.
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
     pub fn speed(&self) -> Option<Speed> {
         self.backend.speed()
     }

--- a/src/platform/linux_usbfs/device.rs
+++ b/src/platform/linux_usbfs/device.rs
@@ -405,6 +405,10 @@ impl LinuxDevice {
         );
         return Err(ErrorKind::Other.into());
     }
+
+    pub(crate) fn descriptors(&self) -> &[u8] {
+        &self.descriptors
+    }
 }
 
 impl Drop for LinuxDevice {

--- a/src/platform/linux_usbfs/device.rs
+++ b/src/platform/linux_usbfs/device.rs
@@ -33,7 +33,7 @@ use crate::{
     transfer::{
         notify_completion, Control, Direction, EndpointType, TransferError, TransferHandle,
     },
-    DeviceInfo, Error,
+    DeviceInfo, Error, Speed,
 };
 
 pub(crate) struct LinuxDevice {
@@ -408,6 +408,20 @@ impl LinuxDevice {
 
     pub(crate) fn descriptors(&self) -> &[u8] {
         &self.descriptors
+    }
+
+    pub(crate) fn get_speed(&self) -> Result<Option<Speed>, Error> {
+        usbfs::get_speed(&self.fd)
+            .map_err(|errno| errno.into())
+            .map(|raw_speed| match raw_speed {
+                1 => Some(Speed::Low),
+                2 => Some(Speed::Full),
+                3 => Some(Speed::High),
+                // 4 is wireless USB, but we don't support it
+                5 => Some(Speed::Super),
+                6 => Some(Speed::SuperPlus),
+                _ => None,
+            })
     }
 }
 

--- a/src/platform/linux_usbfs/device.rs
+++ b/src/platform/linux_usbfs/device.rs
@@ -417,10 +417,11 @@ impl LinuxDevice {
         return Err(ErrorKind::Other.into());
     }
 
-    pub(crate) fn get_speed(&self) -> Result<Option<Speed>, Error> {
+    pub(crate) fn speed(&self) -> Option<Speed> {
         usbfs::get_speed(&self.fd)
-            .map_err(|errno| errno.into())
-            .map(|raw_speed| match raw_speed {
+            .inspect_err(|e| log::error!("USBDEVFS_GET_SPEED failed: {e}"))
+            .ok()
+            .and_then(|raw_speed| match raw_speed {
                 1 => Some(Speed::Low),
                 2 => Some(Speed::Full),
                 3 => Some(Speed::High),

--- a/src/platform/linux_usbfs/usbfs.rs
+++ b/src/platform/linux_usbfs/usbfs.rs
@@ -286,3 +286,10 @@ pub fn clear_halt<Fd: AsFd>(fd: Fd, endpoint: u8) -> io::Result<()> {
         ioctl::ioctl(fd, ctl)
     }
 }
+
+pub fn get_speed<Fd: AsFd>(fd: Fd) -> io::Result<usize> {
+    unsafe {
+        let ctl = Transfer::<ioctl::NoneOpcode<b'U', 31, ()>, ()>::new(());
+        ioctl::ioctl(fd, ctl)
+    }
+}

--- a/src/platform/macos_iokit/enumeration.rs
+++ b/src/platform/macos_iokit/enumeration.rs
@@ -15,7 +15,10 @@ use io_kit_sys::{
 };
 use log::debug;
 
-use crate::{BusInfo, DeviceInfo, Error, InterfaceInfo, Speed, UsbControllerType};
+use crate::{
+    descriptors::DeviceDescriptor, BusInfo, DeviceInfo, Error, InterfaceInfo, Speed,
+    UsbControllerType,
+};
 
 use super::iokit::{IoService, IoServiceIterator};
 /// IOKit class name for PCI USB XHCI high-speed controllers (USB 3.0+)
@@ -266,6 +269,25 @@ fn parse_location_id(id: u32) -> Vec<u8> {
     }
 
     chain
+}
+
+/// There is no API in iokit to get the cached device descriptor as bytes, but
+/// we have all the fields to rebuild it exactly.
+pub(crate) fn device_descriptor_from_fields(device: &IoService) -> Option<DeviceDescriptor> {
+    Some(DeviceDescriptor::from_fields(
+        get_integer_property(&device, "bcdUSB")? as u16,
+        get_integer_property(&device, "bDeviceClass")? as u8,
+        get_integer_property(&device, "bDeviceSubClass")? as u8,
+        get_integer_property(&device, "bDeviceProtocol")? as u8,
+        get_integer_property(&device, "bMaxPacketSize0")? as u8,
+        get_integer_property(&device, "idVendor")? as u16,
+        get_integer_property(&device, "idProduct")? as u16,
+        get_integer_property(&device, "bcdDevice")? as u16,
+        get_integer_property(&device, "iManufacturer")? as u8,
+        get_integer_property(&device, "iProduct")? as u8,
+        get_integer_property(&device, "iSerialNumber")? as u8,
+        get_integer_property(&device, "bNumConfigurations")? as u8,
+    ))
 }
 
 #[test]

--- a/src/platform/macos_iokit/iokit_usb.rs
+++ b/src/platform/macos_iokit/iokit_usb.rs
@@ -39,7 +39,7 @@ pub(crate) struct IoKitDevice {
 
 impl IoKitDevice {
     /// Get the raw USB device associated with the service.
-    pub(crate) fn new(service: IoService) -> Result<IoKitDevice, Error> {
+    pub(crate) fn new(service: &IoService) -> Result<IoKitDevice, Error> {
         unsafe {
             // According to the libusb maintainers, this will sometimes spuriously
             // return `kIOReturnNoResources` for reasons Apple won't explain, usually


### PR DESCRIPTION
Hi! I'm doing some works on Termux. Termux provides a command `termux-usb` for accessing USB device. But it give me only a file descriptor, and I need to get some basic information about the device. So I did some works to get information about the device itself from opened device.

### New Public APIs
 * fn `Device::get_device_descriptor()`
 * ~fn `Device::get_device_info()`~
 * struct `descriptors::DeviceDescriptor`

I'm sorry for the mistakes I made.

# Changelog

### 20250108-1
 * Removed pub fn `device::Device::get_device_info`
 * Removed pub fn `descriptors::DeviceDescriptor::speed`
 * Removed fn `descriptors::DeviceDescriptor::format_usb_version`
 * Removed fn `platform::linux_usbfs::device::LinuxDevice::get_busnum_and_devnum`
 * Removed fn `enumeration::Speed::from_usb_version`
 * Renamed fn `platform::linux_usbfs::device::LinuxDevice::get_descriptors` to `descriptors`
 * Adjusted `Debug` implementation for `descriptors::DeviceDescriptor` to keep the same output format

### 20250114-1
 * Add fn `platform::linux_usbfs::usbfs::get_speed`
 * Add fn `platform::linux_usbfs::device::LinuxDevice::get_speed`
 * Add pub fn `device::Device::get_speed`

Note: The type `descriptors::DeviceDescriptor` is defined as USB standard device descriptor.