### PR TITLE
fix: DeviceIoControl returns false positive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ libc = "0.2.155"
 
 [target.'cfg(target_os="windows")'.dependencies]
 windows-sys = { version = "0.48.0", features = ["Win32_Devices_Usb", "Win32_Devices_DeviceAndDriverInstallation", "Win32_Foundation", "Win32_Devices_Properties", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System_IO", "Win32_System_Registry", "Win32_System_Com"] }
-memx = "0.1.32"
 
 [target.'cfg(target_os="macos")'.dependencies]
 core-foundation = "0.9.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ libc = "0.2.155"
 
 [target.'cfg(target_os="windows")'.dependencies]
 windows-sys = { version = "0.48.0", features = ["Win32_Devices_Usb", "Win32_Devices_DeviceAndDriverInstallation", "Win32_Foundation", "Win32_Devices_Properties", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System_IO", "Win32_System_Registry", "Win32_System_Com"] }
+memx = "0.1.32"
 
 [target.'cfg(target_os="macos")'.dependencies]
 core-foundation = "0.9.3"

--- a/src/platform/windows_winusb/hub.rs
+++ b/src/platform/windows_winusb/hub.rs
@@ -84,17 +84,13 @@ impl HubHandle {
 
             if r == TRUE {
                 const ZERO_DESC: USB_DEVICE_DESCRIPTOR = unsafe { mem::zeroed() };
-                if memx::memcmp(
-                    std::slice::from_raw_parts(
-                        &info.DeviceDescriptor as *const _ as *const u8,
-                        mem::size_of_val(&info.DeviceDescriptor),
-                    ),
-                    std::slice::from_raw_parts(
-                        &ZERO_DESC as *const _ as *const u8,
-                        mem::size_of_val(&ZERO_DESC),
-                    ),
-                ) == std::cmp::Ordering::Equal
-                {
+                if std::slice::from_raw_parts(
+                    &info.DeviceDescriptor as *const _ as *const u8,
+                    mem::size_of_val(&info.DeviceDescriptor),
+                ) == std::slice::from_raw_parts(
+                    &ZERO_DESC as *const _ as *const u8,
+                    mem::size_of_val(&ZERO_DESC),
+                ) {
                     // Win returns false positive in a case where device is detached while DeviceIoControl is invoked.
                     return Err(Error::new(
                         std::io::ErrorKind::Other,

--- a/src/platform/windows_winusb/hub.rs
+++ b/src/platform/windows_winusb/hub.rs
@@ -83,6 +83,24 @@ impl HubHandle {
             );
 
             if r == TRUE {
+                const ZERO_DESC: USB_DEVICE_DESCRIPTOR = unsafe { mem::zeroed() };
+                if memx::memcmp(
+                    std::slice::from_raw_parts(
+                        &info.DeviceDescriptor as *const _ as *const u8,
+                        mem::size_of_val(&info.DeviceDescriptor),
+                    ),
+                    std::slice::from_raw_parts(
+                        &ZERO_DESC as *const _ as *const u8,
+                        mem::size_of_val(&ZERO_DESC),
+                    ),
+                ) == std::cmp::Ordering::Equal
+                {
+                    // Win returns false positive in a case where device is detached while DeviceIoControl is invoked.
+                    return Err(Error::new(
+                        std::io::ErrorKind::Other,
+                        "DeviceIoControl returned success but fields are 0",
+                    ));
+                }
                 Ok(info)
             } else {
                 let err = Error::last_os_error();


### PR DESCRIPTION
This is basically windows issue, can be reproduced by having loop to list devices where device(s) is opened to read manufacturer string while this is running removing the device from usb usually will trigger this. Note all the fields in USB_NODE_CONNECTION_INFORMATION_EX are 0 except ConnectionStatus is 1(connected) usually. Added extra check after DeviceIoControl just to avoid the later point assertion.