### PR TITLE
macos: add kernel driver detaching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ windows-sys = { version = "0.59.0", features = ["Win32_Devices_Usb", "Win32_Devi
 core-foundation = "0.9.3"
 core-foundation-sys = "0.8.4"
 io-kit-sys = "0.4.0"
+libc = "0.2"
 
 [target.'cfg(any(target_os="linux", target_os="android", target_os="windows", target_os="macos"))'.dependencies]
 blocking ="1.6.1"

--- a/src/device.rs
+++ b/src/device.rs
@@ -97,10 +97,10 @@ impl Device {
     /// Attach kernel drivers for the specified interface.
     ///
     /// ### Platform notes
-    /// This function can only attach kernel drivers on Linux. Calling on other platforms has
+    /// This function can only attach kernel drivers on Linux and macOS. Calling on other platforms has
     /// no effect.
     pub fn attach_kernel_driver(&self, interface: u8) -> Result<(), Error> {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         self.backend.attach_kernel_driver(interface)?;
         let _ = interface;
 
@@ -156,6 +156,24 @@ impl Device {
         configuration: u8,
     ) -> impl MaybeFuture<Output = Result<(), Error>> {
         self.backend.clone().set_configuration(configuration)
+    }
+
+    pub fn set_configuration_detached(
+        &self,
+        configuration: u8,
+    ) -> impl MaybeFuture<Output = Result<(), Error>> {
+        self.backend
+            .clone()
+            .set_configuration_detached(configuration)
+    }
+
+    pub fn is_kernel_driver_attached_to_interface(
+        &self,
+        interface_number: u8,
+    ) -> impl MaybeFuture<Output = Result<bool, Error>> {
+        self.backend
+            .clone()
+            .is_kernel_driver_attached_to_interface(interface_number)
     }
 
     /// Request a descriptor from the device.
@@ -265,6 +283,10 @@ impl Device {
     /// * Not supported on Windows
     pub fn reset(&self) -> impl MaybeFuture<Output = Result<(), Error>> {
         self.backend.clone().reset()
+    }
+
+    pub fn reset_captured(&self) -> impl MaybeFuture<Output = Result<(), Error>> {
+        self.backend.clone().reset_detached()
     }
 
     /// Synchronously perform a single **IN (device-to-host)** transfer on the default **control** endpoint.

--- a/src/platform/macos_iokit/iokit_c.rs
+++ b/src/platform/macos_iokit/iokit_c.rs
@@ -22,7 +22,7 @@ use core_foundation_sys::{
 use io_kit_sys::{
     ret::IOReturn,
     types::{io_iterator_t, io_service_t, IOByteCount},
-    IOAsyncCallback1,
+    IOAsyncCallback1, IOAsyncCallback2,
 };
 
 //
@@ -61,6 +61,9 @@ pub(crate) const kIOUSBTransactionTimeout: c_int = SYS_IOKIT | SUB_IOKIT_USB | 0
 
 pub(crate) const kIOUSBFindInterfaceDontCare: UInt16 = 0xFFFF;
 
+pub(crate) const kUSBReEnumerateCaptureDeviceBit: u32 = 30;
+pub(crate) const kUSBReEnumerateCaptureDeviceMask: u32 = 1 << kUSBReEnumerateCaptureDeviceBit;
+
 //
 
 //
@@ -78,6 +81,24 @@ pub(crate) type kern_return_t = ::std::os::raw::c_int;
 pub(crate) type USBDeviceAddress = UInt16;
 pub(crate) type AbsoluteTime = UnsignedWide;
 pub(crate) type Boolean = std::os::raw::c_uchar;
+
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct IOUSBEndpointProperties {
+    pub bVersion: UInt8,
+    pub bAlternateSetting: UInt8,
+    pub bDirection: UInt8,
+    pub bEndpointNumber: UInt8,
+    pub bTransferType: UInt8,
+    pub bUsageType: UInt8,
+    pub bSyncType: UInt8,
+    pub bInterval: UInt8,
+    pub wMaxPacketSize: UInt16,
+    pub bMaxBurst: UInt8,
+    pub bMaxStreams: UInt8,
+    pub bMult: UInt8,
+    pub wBytesPerInterval: UInt16,
+}
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -323,6 +344,30 @@ pub fn kIOUSBDeviceInterfaceID500() -> CFUUIDRef {
     }
 }
 
+pub fn kIOUSBDeviceInterfaceID650() -> CFUUIDRef {
+    unsafe {
+        CFUUIDGetConstantUUIDWithBytes(
+            kCFAllocatorSystemDefault,
+            0x4A,
+            0xAC,
+            0x1B,
+            0x2E,
+            0x24,
+            0xC2,
+            0x47,
+            0x6A,
+            0x96,
+            0x4D,
+            0x91,
+            0x33,
+            0x35,
+            0x34,
+            0xF2,
+            0xCC,
+        )
+    }
+}
+
 pub fn kIOUSBInterfaceInterfaceID500() -> CFUUIDRef {
     unsafe {
         CFUUIDGetConstantUUIDWithBytes(
@@ -343,6 +388,30 @@ pub fn kIOUSBInterfaceInterfaceID500() -> CFUUIDRef {
             0xDD,
             0xAC,
             0x16,
+        )
+    }
+}
+
+pub fn kIOUSBInterfaceInterfaceID700() -> CFUUIDRef {
+    unsafe {
+        CFUUIDGetConstantUUIDWithBytes(
+            kCFAllocatorSystemDefault,
+            0x17,
+            0xF9,
+            0xE5,
+            0x9C,
+            0xB0,
+            0xA1,
+            0x40,
+            0x1D,
+            0x9A,
+            0xC0,
+            0x8D,
+            0xE2,
+            0x7A,
+            0xC6,
+            0x04,
+            0x7E,
         )
     }
 }
@@ -594,6 +663,269 @@ pub type IOUSBDeviceInterface500 = IOUSBDeviceStruct500;
 // device in Mutex somewhere up from here.)
 unsafe impl Send for IOUSBDeviceInterface500 {}
 unsafe impl Sync for IOUSBDeviceInterface500 {}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct IOUSBDeviceStruct650 {
+    pub _reserved: *mut ::std::os::raw::c_void,
+    pub QueryInterface: ::std::option::Option<
+        unsafe extern "C" fn(
+            thisPointer: *mut ::std::os::raw::c_void,
+            iid: REFIID,
+            ppv: *mut LPVOID,
+        ) -> HRESULT,
+    >,
+    pub AddRef: ::std::option::Option<
+        unsafe extern "C" fn(thisPointer: *mut ::std::os::raw::c_void) -> ULONG,
+    >,
+    pub Release: ::std::option::Option<
+        unsafe extern "C" fn(thisPointer: *mut ::std::os::raw::c_void) -> ULONG,
+    >,
+    pub CreateDeviceAsyncEventSource: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            source: *mut CFRunLoopSourceRef,
+        ) -> IOReturn,
+    >,
+    pub GetDeviceAsyncEventSource: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void) -> CFRunLoopSourceRef,
+    >,
+    pub CreateDeviceAsyncPort: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            port: *mut mach_port_t,
+        ) -> IOReturn,
+    >,
+    pub GetDeviceAsyncPort: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void) -> mach_port_t,
+    >,
+    pub USBDeviceOpen:
+        ::std::option::Option<unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void) -> IOReturn>,
+    pub USBDeviceClose:
+        ::std::option::Option<unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void) -> IOReturn>,
+    pub GetDeviceClass: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void, devClass: *mut UInt8) -> IOReturn,
+    >,
+    pub GetDeviceSubClass: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            devSubClass: *mut UInt8,
+        ) -> IOReturn,
+    >,
+    pub GetDeviceProtocol: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            devProtocol: *mut UInt8,
+        ) -> IOReturn,
+    >,
+    pub GetDeviceVendor: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            devVendor: *mut UInt16,
+        ) -> IOReturn,
+    >,
+    pub GetDeviceProduct: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            devProduct: *mut UInt16,
+        ) -> IOReturn,
+    >,
+    pub GetDeviceReleaseNumber: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            devRelNum: *mut UInt16,
+        ) -> IOReturn,
+    >,
+    pub GetDeviceAddress: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            addr: *mut USBDeviceAddress,
+        ) -> IOReturn,
+    >,
+    pub GetDeviceBusPowerAvailable: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            powerAvailable: *mut UInt32,
+        ) -> IOReturn,
+    >,
+    pub GetDeviceSpeed: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void, devSpeed: *mut UInt8) -> IOReturn,
+    >,
+    pub GetNumberOfConfigurations: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void, numConfig: *mut UInt8) -> IOReturn,
+    >,
+    pub GetLocationID: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            locationID: *mut UInt32,
+        ) -> IOReturn,
+    >,
+    pub GetConfigurationDescriptorPtr: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            configIndex: UInt8,
+            desc: *mut IOUSBConfigurationDescriptorPtr,
+        ) -> IOReturn,
+    >,
+    pub GetConfiguration: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void, configNum: *mut UInt8) -> IOReturn,
+    >,
+    pub SetConfiguration: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void, configNum: UInt8) -> IOReturn,
+    >,
+    pub GetBusFrameNumber: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            frame: *mut UInt64,
+            atTime: *mut AbsoluteTime,
+        ) -> IOReturn,
+    >,
+    pub ResetDevice:
+        ::std::option::Option<unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void) -> IOReturn>,
+    pub DeviceRequest: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            req: *mut IOUSBDevRequest,
+        ) -> IOReturn,
+    >,
+    pub DeviceRequestAsync: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            req: *mut IOUSBDevRequest,
+            callback: IOAsyncCallback1,
+            refCon: *mut ::std::os::raw::c_void,
+        ) -> IOReturn,
+    >,
+    pub CreateInterfaceIterator: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            req: *mut IOUSBFindInterfaceRequest,
+            iter: *mut io_iterator_t,
+        ) -> IOReturn,
+    >,
+    pub USBDeviceOpenSeize:
+        ::std::option::Option<unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void) -> IOReturn>,
+    pub DeviceRequestTO: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            req: *mut IOUSBDevRequestTO,
+        ) -> IOReturn,
+    >,
+    pub DeviceRequestAsyncTO: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            req: *mut IOUSBDevRequestTO,
+            callback: IOAsyncCallback1,
+            refCon: *mut ::std::os::raw::c_void,
+        ) -> IOReturn,
+    >,
+    pub USBDeviceSuspend: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void, suspend: Boolean) -> IOReturn,
+    >,
+    pub USBDeviceAbortPipeZero:
+        ::std::option::Option<unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void) -> IOReturn>,
+    pub USBGetManufacturerStringIndex: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void, msi: *mut UInt8) -> IOReturn,
+    >,
+    pub USBGetProductStringIndex: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void, psi: *mut UInt8) -> IOReturn,
+    >,
+    pub USBGetSerialNumberStringIndex: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void, snsi: *mut UInt8) -> IOReturn,
+    >,
+    pub USBDeviceReEnumerate: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void, options: UInt32) -> IOReturn,
+    >,
+    pub GetBusMicroFrameNumber: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            microFrame: *mut UInt64,
+            atTime: *mut AbsoluteTime,
+        ) -> IOReturn,
+    >,
+    pub GetIOUSBLibVersion: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            ioUSBLibVersion: *mut NumVersion,
+            usbFamilyVersion: *mut NumVersion,
+        ) -> IOReturn,
+    >,
+    pub GetBusFrameNumberWithTime: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            frame: *mut UInt64,
+            atTime: *mut AbsoluteTime,
+        ) -> IOReturn,
+    >,
+    pub GetUSBDeviceInformation: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void, info: *mut UInt32) -> IOReturn,
+    >,
+    pub RequestExtraPower: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            type_: UInt32,
+            requestedPower: UInt32,
+            powerAvailable: *mut UInt32,
+        ) -> IOReturn,
+    >,
+    pub ReturnExtraPower: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            type_: UInt32,
+            powerReturned: UInt32,
+        ) -> IOReturn,
+    >,
+    pub GetExtraPowerAllocated: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            type_: UInt32,
+            powerAllocated: *mut UInt32,
+        ) -> IOReturn,
+    >,
+    pub GetBandwidthAvailableForDevice: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            bandwidth: *mut UInt32,
+        ) -> IOReturn,
+    >,
+    pub SetConfigurationV2: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            configNum: UInt8,
+            startInterfaceMatching: bool,
+            issueRemoteWakeup: bool,
+        ) -> IOReturn,
+    >,
+    pub RegisterForNotification: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            notificationMask: UInt64,
+            callback: IOAsyncCallback2,
+            refCon: *mut ::std::os::raw::c_void,
+            pRegistrationToken: *mut UInt64,
+        ) -> IOReturn,
+    >,
+    pub UnregisterNotification: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            registrationToken: UInt64,
+        ) -> IOReturn,
+    >,
+    pub AcknowledgeNotification: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            notificationToken: UInt64,
+        ) -> IOReturn,
+    >,
+}
+pub type IOUSBDeviceInterface650 = IOUSBDeviceStruct650;
+
+// Tweak: these are just function pointers to thread-safe functions,
+// so add send and sync to the C-type. (Calling these from multiple threads
+// may cause odd behavior on the USB bus, though, so we'll still want to wrap the
+// device in Mutex somewhere up from here.)
+unsafe impl Send for IOUSBDeviceInterface650 {}
+unsafe impl Sync for IOUSBDeviceInterface650 {}
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1008,3 +1340,530 @@ pub struct IOUSBInterfaceStruct500 {
 // device in Mutex somewhere up from here.)
 unsafe impl Send for IOUSBInterfaceStruct500 {}
 unsafe impl Sync for IOUSBInterfaceStruct500 {}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct IOUSBInterfaceStruct700 {
+    pub _reserved: *mut ::std::os::raw::c_void,
+    pub QueryInterface: ::std::option::Option<
+        unsafe extern "C" fn(
+            thisPointer: *mut ::std::os::raw::c_void,
+            iid: REFIID,
+            ppv: *mut LPVOID,
+        ) -> HRESULT,
+    >,
+    pub AddRef: ::std::option::Option<
+        unsafe extern "C" fn(thisPointer: *mut ::std::os::raw::c_void) -> ULONG,
+    >,
+    pub Release: ::std::option::Option<
+        unsafe extern "C" fn(thisPointer: *mut ::std::os::raw::c_void) -> ULONG,
+    >,
+    pub CreateInterfaceAsyncEventSource: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            source: *mut CFRunLoopSourceRef,
+        ) -> IOReturn,
+    >,
+    pub GetInterfaceAsyncEventSource: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void) -> CFRunLoopSourceRef,
+    >,
+    pub CreateInterfaceAsyncPort: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            port: *mut mach_port_t,
+        ) -> IOReturn,
+    >,
+    pub GetInterfaceAsyncPort: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void) -> mach_port_t,
+    >,
+    pub USBInterfaceOpen:
+        ::std::option::Option<unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void) -> IOReturn>,
+    pub USBInterfaceClose:
+        ::std::option::Option<unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void) -> IOReturn>,
+    pub GetInterfaceClass: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void, intfClass: *mut UInt8) -> IOReturn,
+    >,
+    pub GetInterfaceSubClass: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            intfSubClass: *mut UInt8,
+        ) -> IOReturn,
+    >,
+    pub GetInterfaceProtocol: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            intfProtocol: *mut UInt8,
+        ) -> IOReturn,
+    >,
+    pub GetDeviceVendor: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            devVendor: *mut UInt16,
+        ) -> IOReturn,
+    >,
+    pub GetDeviceProduct: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            devProduct: *mut UInt16,
+        ) -> IOReturn,
+    >,
+    pub GetDeviceReleaseNumber: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            devRelNum: *mut UInt16,
+        ) -> IOReturn,
+    >,
+    pub GetConfigurationValue: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void, configVal: *mut UInt8) -> IOReturn,
+    >,
+    pub GetInterfaceNumber: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            intfNumber: *mut UInt8,
+        ) -> IOReturn,
+    >,
+    pub GetAlternateSetting: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            intfAltSetting: *mut UInt8,
+        ) -> IOReturn,
+    >,
+    pub GetNumEndpoints: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            intfNumEndpoints: *mut UInt8,
+        ) -> IOReturn,
+    >,
+    pub GetLocationID: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            locationID: *mut UInt32,
+        ) -> IOReturn,
+    >,
+    pub GetDevice: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            device: *mut io_service_t,
+        ) -> IOReturn,
+    >,
+    pub SetAlternateInterface: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            alternateSetting: UInt8,
+        ) -> IOReturn,
+    >,
+    pub GetBusFrameNumber: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            frame: *mut UInt64,
+            atTime: *mut AbsoluteTime,
+        ) -> IOReturn,
+    >,
+    pub ControlRequest: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            req: *mut IOUSBDevRequest,
+        ) -> IOReturn,
+    >,
+    pub ControlRequestAsync: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            req: *mut IOUSBDevRequest,
+            callback: IOAsyncCallback1,
+            refCon: *mut ::std::os::raw::c_void,
+        ) -> IOReturn,
+    >,
+    pub GetPipeProperties: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            direction: *mut UInt8,
+            number: *mut UInt8,
+            transferType: *mut UInt8,
+            maxPacketSize: *mut UInt16,
+            interval: *mut UInt8,
+        ) -> IOReturn,
+    >,
+    pub GetPipeStatus: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void, pipeRef: UInt8) -> IOReturn,
+    >,
+    pub AbortPipe: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void, pipeRef: UInt8) -> IOReturn,
+    >,
+    pub ResetPipe: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void, pipeRef: UInt8) -> IOReturn,
+    >,
+    pub ClearPipeStall: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void, pipeRef: UInt8) -> IOReturn,
+    >,
+    pub ReadPipe: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            buf: *mut ::std::os::raw::c_void,
+            size: *mut UInt32,
+        ) -> IOReturn,
+    >,
+    pub WritePipe: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            buf: *mut ::std::os::raw::c_void,
+            size: UInt32,
+        ) -> IOReturn,
+    >,
+    pub ReadPipeAsync: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            buf: *mut ::std::os::raw::c_void,
+            size: UInt32,
+            callback: IOAsyncCallback1,
+            refcon: *mut ::std::os::raw::c_void,
+        ) -> IOReturn,
+    >,
+    pub WritePipeAsync: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            buf: *mut ::std::os::raw::c_void,
+            size: UInt32,
+            callback: IOAsyncCallback1,
+            refcon: *mut ::std::os::raw::c_void,
+        ) -> IOReturn,
+    >,
+    pub ReadIsochPipeAsync: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            buf: *mut ::std::os::raw::c_void,
+            frameStart: UInt64,
+            numFrames: UInt32,
+            frameList: *mut IOUSBIsocFrame,
+            callback: IOAsyncCallback1,
+            refcon: *mut ::std::os::raw::c_void,
+        ) -> IOReturn,
+    >,
+    pub WriteIsochPipeAsync: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            buf: *mut ::std::os::raw::c_void,
+            frameStart: UInt64,
+            numFrames: UInt32,
+            frameList: *mut IOUSBIsocFrame,
+            callback: IOAsyncCallback1,
+            refcon: *mut ::std::os::raw::c_void,
+        ) -> IOReturn,
+    >,
+    pub ControlRequestTO: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            req: *mut IOUSBDevRequestTO,
+        ) -> IOReturn,
+    >,
+    pub ControlRequestAsyncTO: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            req: *mut IOUSBDevRequestTO,
+            callback: IOAsyncCallback1,
+            refCon: *mut ::std::os::raw::c_void,
+        ) -> IOReturn,
+    >,
+    pub ReadPipeTO: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            buf: *mut ::std::os::raw::c_void,
+            size: *mut UInt32,
+            noDataTimeout: UInt32,
+            completionTimeout: UInt32,
+        ) -> IOReturn,
+    >,
+    pub WritePipeTO: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            buf: *mut ::std::os::raw::c_void,
+            size: UInt32,
+            noDataTimeout: UInt32,
+            completionTimeout: UInt32,
+        ) -> IOReturn,
+    >,
+    pub ReadPipeAsyncTO: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            buf: *mut ::std::os::raw::c_void,
+            size: UInt32,
+            noDataTimeout: UInt32,
+            completionTimeout: UInt32,
+            callback: IOAsyncCallback1,
+            refcon: *mut ::std::os::raw::c_void,
+        ) -> IOReturn,
+    >,
+    pub WritePipeAsyncTO: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            buf: *mut ::std::os::raw::c_void,
+            size: UInt32,
+            noDataTimeout: UInt32,
+            completionTimeout: UInt32,
+            callback: IOAsyncCallback1,
+            refcon: *mut ::std::os::raw::c_void,
+        ) -> IOReturn,
+    >,
+    pub USBInterfaceGetStringIndex: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void, si: *mut UInt8) -> IOReturn,
+    >,
+    pub USBInterfaceOpenSeize:
+        ::std::option::Option<unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void) -> IOReturn>,
+    pub ClearPipeStallBothEnds: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void, pipeRef: UInt8) -> IOReturn,
+    >,
+    pub SetPipePolicy: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            maxPacketSize: UInt16,
+            maxInterval: UInt8,
+        ) -> IOReturn,
+    >,
+    pub GetBandwidthAvailable: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            bandwidth: *mut UInt32,
+        ) -> IOReturn,
+    >,
+    pub GetEndpointProperties: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            alternateSetting: UInt8,
+            endpointNumber: UInt8,
+            direction: UInt8,
+            transferType: *mut UInt8,
+            maxPacketSize: *mut UInt16,
+            interval: *mut UInt8,
+        ) -> IOReturn,
+    >,
+    pub LowLatencyReadIsochPipeAsync: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            buf: *mut ::std::os::raw::c_void,
+            frameStart: UInt64,
+            numFrames: UInt32,
+            updateFrequency: UInt32,
+            frameList: *mut IOUSBLowLatencyIsocFrame,
+            callback: IOAsyncCallback1,
+            refcon: *mut ::std::os::raw::c_void,
+        ) -> IOReturn,
+    >,
+    pub LowLatencyWriteIsochPipeAsync: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            buf: *mut ::std::os::raw::c_void,
+            frameStart: UInt64,
+            numFrames: UInt32,
+            updateFrequency: UInt32,
+            frameList: *mut IOUSBLowLatencyIsocFrame,
+            callback: IOAsyncCallback1,
+            refcon: *mut ::std::os::raw::c_void,
+        ) -> IOReturn,
+    >,
+    pub LowLatencyCreateBuffer: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            buffer: *mut *mut ::std::os::raw::c_void,
+            size: IOByteCount,
+            bufferType: UInt32,
+        ) -> IOReturn,
+    >,
+    pub LowLatencyDestroyBuffer: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            buffer: *mut ::std::os::raw::c_void,
+        ) -> IOReturn,
+    >,
+    pub GetBusMicroFrameNumber: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            microFrame: *mut UInt64,
+            atTime: *mut AbsoluteTime,
+        ) -> IOReturn,
+    >,
+    pub GetFrameListTime: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            microsecondsInFrame: *mut UInt32,
+        ) -> IOReturn,
+    >,
+    pub GetIOUSBLibVersion: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            ioUSBLibVersion: *mut NumVersion,
+            usbFamilyVersion: *mut NumVersion,
+        ) -> IOReturn,
+    >,
+    pub FindNextAssociatedDescriptor: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            currentDescriptor: *const ::std::os::raw::c_void,
+            descriptorType: UInt8,
+        ) -> *mut IOUSBDescriptorHeader,
+    >,
+    pub FindNextAltInterface: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            current: *const ::std::os::raw::c_void,
+            request: *mut IOUSBFindInterfaceRequest,
+        ) -> *mut IOUSBDescriptorHeader,
+    >,
+    pub GetBusFrameNumberWithTime: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            frame: *mut UInt64,
+            atTime: *mut AbsoluteTime,
+        ) -> IOReturn,
+    >,
+    pub GetPipePropertiesV2: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            direction: *mut UInt8,
+            number: *mut UInt8,
+            transferType: *mut UInt8,
+            maxPacketSize: *mut UInt16,
+            interval: *mut UInt8,
+            maxBurst: *mut UInt8,
+            mult: *mut UInt8,
+            bytesPerInterval: *mut UInt16,
+        ) -> IOReturn,
+    >,
+    pub GetPipePropertiesV3: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            properties: *mut IOUSBEndpointProperties,
+        ) -> IOReturn,
+    >,
+    pub GetEndpointPropertiesV3: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            properties: *mut IOUSBEndpointProperties,
+        ) -> IOReturn,
+    >,
+    pub SupportsStreams: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            supportsStreams: *mut UInt32,
+        ) -> IOReturn,
+    >,
+    pub CreateStreams: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            streamID: UInt32,
+        ) -> IOReturn,
+    >,
+    pub GetConfiguredStreams: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            configuredStreams: *mut UInt32,
+        ) -> IOReturn,
+    >,
+    pub ReadStreamsPipeTO: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            streamID: UInt32,
+            buf: *mut ::std::os::raw::c_void,
+            size: *mut UInt32,
+            noDataTimeout: UInt32,
+            completionTimeout: UInt32,
+        ) -> IOReturn,
+    >,
+    pub WriteStreamsPipeTO: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            streamID: UInt32,
+            buf: *mut ::std::os::raw::c_void,
+            size: UInt32,
+            noDataTimeout: UInt32,
+            completionTimeout: UInt32,
+        ) -> IOReturn,
+    >,
+    pub ReadStreamsPipeAsyncTO: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            streamID: UInt32,
+            buf: *mut ::std::os::raw::c_void,
+            size: UInt32,
+            noDataTimeout: UInt32,
+            completionTimeout: UInt32,
+            callback: IOAsyncCallback1,
+            refcon: *mut ::std::os::raw::c_void,
+        ) -> IOReturn,
+    >,
+    pub WriteStreamsPipeAsyncTO: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            streamID: UInt32,
+            buf: *mut ::std::os::raw::c_void,
+            size: UInt32,
+            noDataTimeout: UInt32,
+            completionTimeout: UInt32,
+            callback: IOAsyncCallback1,
+            refcon: *mut ::std::os::raw::c_void,
+        ) -> IOReturn,
+    >,
+    pub AbortStreamsPipe: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            pipeRef: UInt8,
+            streamID: UInt32,
+        ) -> IOReturn,
+    >,
+    pub RegisterForNotification: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            notificationMask: UInt64,
+            callback: IOAsyncCallback2,
+            refCon: *mut ::std::os::raw::c_void,
+            pRegistrationToken: *mut UInt64,
+        ) -> IOReturn,
+    >,
+    pub UnregisterNotification: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            registrationToken: UInt64,
+        ) -> IOReturn,
+    >,
+    pub AcknowledgeNotification: ::std::option::Option<
+        unsafe extern "C" fn(
+            self_: *mut ::std::os::raw::c_void,
+            notificationToken: UInt64,
+        ) -> IOReturn,
+    >,
+    pub RegisterDriver:
+        ::std::option::Option<unsafe extern "C" fn(self_: *mut ::std::os::raw::c_void) -> IOReturn>,
+}
+pub type IOUSBInterfaceInterface700 = IOUSBInterfaceStruct700;
+
+// Tweak: these are just function pointers to thread-safe functions,
+// so add send and sync to the C-type. (Calling these from multiple threads
+// may cause odd behavior on the USB bus, though, so we'll still want to wrap the
+// device in Mutex somewhere up from here.)
+unsafe impl Send for IOUSBInterfaceInterface700 {}
+unsafe impl Sync for IOUSBInterfaceInterface700 {}

--- a/src/platform/macos_iokit/mod.rs
+++ b/src/platform/macos_iokit/mod.rs
@@ -1,5 +1,6 @@
 mod transfer;
 use io_kit_sys::ret::IOReturn;
+use once_cell::sync::OnceCell;
 pub(crate) use transfer::TransferData;
 
 mod enumeration;
@@ -31,5 +32,92 @@ fn status_to_transfer_result(status: IOReturn) -> Result<(), TransferError> {
         io_kit_sys::ret::kIOReturnAborted => Err(TransferError::Cancelled),
         iokit_c::kIOUSBPipeStalled => Err(TransferError::Stall),
         _ => Err(TransferError::Unknown),
+    }
+}
+
+type OsVersion = (u8, u8, u8);
+
+pub(crate) fn os_version() -> OsVersion {
+    static VERSION: OnceCell<OsVersion> = OnceCell::new();
+    *VERSION.get_or_init(|| {
+        read_osproductversion()
+            .or_else(|| read_osrelease())
+            .unwrap_or((10, 0, 0))
+    })
+}
+
+fn read_osproductversion() -> Option<OsVersion> {
+    unsafe {
+        let mut buffer: [libc::c_char; 64] = [0; 64];
+        let mut len: libc::size_t = buffer.len() - 1;
+
+        let ret = libc::sysctlbyname(
+            "kern.osproductversion\0".as_ptr() as *const libc::c_char,
+            buffer.as_mut_ptr() as *mut _,
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        );
+
+        if ret != 0 {
+            return None;
+        }
+
+        let os_product_version_string = std::ffi::CStr::from_ptr(buffer.as_ptr()).to_str().ok()?;
+        let mut parts = os_product_version_string.split(".");
+        let major = parts.next().and_then(|s| s.parse().ok())?;
+        let minor = parts.next().and_then(|s| s.parse().ok())?;
+        let patch = parts.next().and_then(|s| s.parse().ok())?;
+        let version = (major, minor, patch);
+
+        return Some(version);
+    }
+}
+
+fn read_osrelease() -> Option<OsVersion> {
+    unsafe {
+        let mut buffer: [libc::c_char; 64] = [0; 64];
+        let mut len: libc::size_t = buffer.len() - 1;
+
+        let ret = libc::sysctlbyname(
+            "kern.osrelease\0".as_ptr() as *const libc::c_char,
+            buffer.as_mut_ptr() as *mut _,
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        );
+
+        if ret != 0 {
+            return None;
+        }
+
+        let os_release_string = std::ffi::CStr::from_ptr(buffer.as_ptr()).to_str().ok()?;
+        let mut parts = os_release_string.split(".");
+        let darwin_major: u8 = parts.next().and_then(|s| s.parse().ok())?;
+        let darwin_minor: u8 = parts.next().and_then(|s| s.parse().ok())?;
+
+        let major;
+        let minor;
+        let patch;
+        if darwin_major == 1 && darwin_minor < 4 {
+            major = 10;
+            minor = 0;
+            patch = 0;
+        } else if darwin_major < 6 {
+            major = 10;
+            minor = 1;
+            patch = 0;
+        } else if darwin_major < 20 {
+            major = 10;
+            minor = darwin_major - 4;
+            patch = darwin_minor;
+        } else {
+            major = darwin_major - 9;
+            minor = darwin_minor;
+            patch = 0;
+        }
+        let version = (major, minor, patch);
+
+        return Some(version);
     }
 }


### PR DESCRIPTION
Hi Kevin,

For macOS, this adds support for attaching/detaching kernel drivers to/from interfaces, and checking if there is a kernel driver presently attached to a given interface. Testing shows that things seem to be working as desired (I eventually intend to use this in a cross platform, open source pen tablet driver, starting with macOS and Linux).

On macOS, the only way to detach drivers is to either reset the device by enumerating with `kUSBReEnumerateCaptureDeviceMask` (which `libusb` supports), or re-configure the device via `SetConfigurationV2` with `startInterfaceMatching=false` (which `libusb` does _not_ support). Individual interfaces can then have kernel drivers (re)attached.

I've added new interface declarations with the minimum version that adds the function pointers I need. For now, I've switched the type aliases over to these newer versions, but breaks support for older versions of macOS. How would you like to resolve that -- perhaps an `enum` over the two interface versions, or a new `struct` that cherry picks the function points we need?

I haven't added `is_kernel_driver_attached_to_interface` support for the other OSes, so the build is broken for those.

I added `os_version` to get the os version via `sysctls`, thinking that we might want to do something similar to `libusb` where they choose the latest available device/interface interface version, but I wasn't sure if / how you'd want to go about that, so `os_version` is currently unused.

I wasn't sure about naming in a number of places ("detached" vs "captured", for instance), so names may be a bit inconsistent / less than ideal.

Let me know how you'd like me to address the remaining issues (or, if it would be less of a bother for you to touch things up yourself, feel free).