### PR TITLE
Add usb version to device info

### DIFF
--- a/src/enumeration.rs
+++ b/src/enumeration.rs
@@ -60,6 +60,7 @@ pub struct DeviceInfo {
     pub(crate) product_id: u16,
     pub(crate) device_version: u16,
 
+    pub(crate) usb_version: u16,
     pub(crate) class: u8,
     pub(crate) subclass: u8,
     pub(crate) protocol: u8,
@@ -200,6 +201,12 @@ impl DeviceInfo {
         self.device_version
     }
 
+    /// Encoded version of the USB specification, from the `bcdUSB` device descriptor field.
+    #[doc(alias = "bcdUSB")]
+    pub fn usb_version(&self) -> u16 {
+        self.usb_version
+    }
+
     /// Code identifying the standard device class, from the `bDeviceClass` device descriptor field.
     ///
     /// `0x00`: specified at the interface level.\
@@ -295,6 +302,10 @@ impl std::fmt::Debug for DeviceInfo {
             .field(
                 "device_version",
                 &format_args!("0x{:04X}", self.device_version),
+            )
+            .field(
+                "usb_version",
+                   &format_args!("0x{:04X}", self.usb_version),
             )
             .field("class", &format_args!("0x{:02X}", self.class))
             .field("subclass", &format_args!("0x{:02X}", self.subclass))

--- a/src/enumeration.rs
+++ b/src/enumeration.rs
@@ -303,10 +303,7 @@ impl std::fmt::Debug for DeviceInfo {
                 "device_version",
                 &format_args!("0x{:04X}", self.device_version),
             )
-            .field(
-                "usb_version",
-                   &format_args!("0x{:04X}", self.usb_version),
-            )
+            .field("usb_version", &format_args!("0x{:04X}", self.usb_version))
             .field("class", &format_args!("0x{:02X}", self.class))
             .field("subclass", &format_args!("0x{:02X}", self.subclass))
             .field("protocol", &format_args!("0x{:02X}", self.protocol))

--- a/src/platform/linux_usbfs/enumeration.rs
+++ b/src/platform/linux_usbfs/enumeration.rs
@@ -3,7 +3,6 @@ use std::io;
 use std::num::ParseIntError;
 use std::path::PathBuf;
 use std::str::FromStr;
-
 use log::debug;
 use log::warn;
 
@@ -72,6 +71,20 @@ impl SysfsPath {
 
     fn read_attr_hex<T: FromHexStr>(&self, attr: &str) -> Result<T, SysfsError> {
         self.parse_attr(attr, |s| T::from_hex_str(s.strip_prefix("0x").unwrap_or(s)))
+    }
+
+    fn read_version_attr(&self, attr: &str) -> Result<u16, SysfsError> {
+        // in sysfs bcdUSB is parsed to `x.yz`, so we have to parse it manually. It is bcd, so we can treat parts as hex.
+        self.parse_attr(attr, |s| s
+            .to_owned()
+            .split('.')
+            .map(|x|u16::from_hex_str(x))
+            .fold(Ok::<u16, ParseIntError>(0),
+                  |a,b| Ok((a? << 8) + b?)))
+
+        // let version_string = self.read_attr::<String>(attr)?;
+        // let version = version_string.split('.').map(|x|u16::from_hex_str(x).ok()).fold(Some(0), |a,b| Some((a? << 8) + b?));
+        // version.ok_or(SysfsError(self.0.join(attr), SysfsErrorKind::Parse(format!("Cannot parse version string: {:?}", version))))
     }
 
     pub(crate) fn readlink_attr_filename(&self, attr: &str) -> Result<String, SysfsError> {
@@ -214,6 +227,7 @@ pub fn probe_device(path: SysfsPath) -> Result<DeviceInfo, SysfsError> {
         vendor_id: path.read_attr_hex("idVendor")?,
         product_id: path.read_attr_hex("idProduct")?,
         device_version: path.read_attr_hex("bcdDevice")?,
+        usb_version: path.read_version_attr("version")?,
         class: path.read_attr_hex("bDeviceClass")?,
         subclass: path.read_attr_hex("bDeviceSubClass")?,
         protocol: path.read_attr_hex("bDeviceProtocol")?,

--- a/src/platform/linux_usbfs/enumeration.rs
+++ b/src/platform/linux_usbfs/enumeration.rs
@@ -75,12 +75,12 @@ impl SysfsPath {
 
     fn read_version_attr(&self, attr: &str) -> Result<u16, SysfsError> {
         // in sysfs bcdUSB is parsed to `x.yz`, so we have to parse it back. It should be coded in bcd, so we can treat parts as hex.
-        self.parse_attr(attr, |s| s
-            .to_owned()
-            .split('.')
-            .map(|x|u16::from_hex_str(x))
-            .fold(Ok::<u16, ParseIntError>(0),
-                  |a,b| Ok((a? << 8) + b?)))
+        self.parse_attr(attr, |s| {
+            s.to_owned()
+                .split('.')
+                .map(|x| u16::from_hex_str(x))
+                .fold(Ok::<u16, ParseIntError>(0), |a, b| Ok((a? << 8) + b?))
+        })
     }
 
     pub(crate) fn readlink_attr_filename(&self, attr: &str) -> Result<String, SysfsError> {

--- a/src/platform/linux_usbfs/enumeration.rs
+++ b/src/platform/linux_usbfs/enumeration.rs
@@ -1,10 +1,10 @@
+use log::debug;
+use log::warn;
 use std::fs;
 use std::io;
 use std::num::ParseIntError;
 use std::path::PathBuf;
 use std::str::FromStr;
-use log::debug;
-use log::warn;
 
 use crate::enumeration::InterfaceInfo;
 use crate::maybe_future::{MaybeFuture, Ready};

--- a/src/platform/linux_usbfs/enumeration.rs
+++ b/src/platform/linux_usbfs/enumeration.rs
@@ -74,17 +74,13 @@ impl SysfsPath {
     }
 
     fn read_version_attr(&self, attr: &str) -> Result<u16, SysfsError> {
-        // in sysfs bcdUSB is parsed to `x.yz`, so we have to parse it manually. It is bcd, so we can treat parts as hex.
+        // in sysfs bcdUSB is parsed to `x.yz`, so we have to parse it back. It should be coded in bcd, so we can treat parts as hex.
         self.parse_attr(attr, |s| s
             .to_owned()
             .split('.')
             .map(|x|u16::from_hex_str(x))
             .fold(Ok::<u16, ParseIntError>(0),
                   |a,b| Ok((a? << 8) + b?)))
-
-        // let version_string = self.read_attr::<String>(attr)?;
-        // let version = version_string.split('.').map(|x|u16::from_hex_str(x).ok()).fold(Some(0), |a,b| Some((a? << 8) + b?));
-        // version.ok_or(SysfsError(self.0.join(attr), SysfsErrorKind::Parse(format!("Cannot parse version string: {:?}", version))))
     }
 
     pub(crate) fn readlink_attr_filename(&self, attr: &str) -> Result<String, SysfsError> {

--- a/src/platform/macos_iokit/enumeration.rs
+++ b/src/platform/macos_iokit/enumeration.rs
@@ -124,6 +124,7 @@ pub(crate) fn probe_device(device: IoService) -> Option<DeviceInfo> {
         vendor_id: get_integer_property(&device, "idVendor")? as u16,
         product_id: get_integer_property(&device, "idProduct")? as u16,
         device_version: get_integer_property(&device, "bcdDevice")? as u16,
+        usb_version: get_integer_property(&device, "bcdUSB")? as u16,
         class: get_integer_property(&device, "bDeviceClass")? as u8,
         subclass: get_integer_property(&device, "bDeviceSubClass")? as u8,
         protocol: get_integer_property(&device, "bDeviceProtocol")? as u8,

--- a/src/platform/windows_winusb/enumeration.rs
+++ b/src/platform/windows_winusb/enumeration.rs
@@ -142,6 +142,7 @@ pub fn probe_device(devinst: DevInst) -> Option<DeviceInfo> {
         vendor_id: info.device_desc.idVendor,
         product_id: info.device_desc.idProduct,
         device_version: info.device_desc.bcdDevice,
+        usb_version: info.device_desc.bcdUSB,
         class: info.device_desc.bDeviceClass,
         subclass: info.device_desc.bDeviceSubClass,
         protocol: info.device_desc.bDeviceProtocol,


### PR DESCRIPTION
Added missing usb version (aka bcdUSB) to DeviceInfo. On Windows it is available in device descriptor directly. On linux it is in sysfs as version and it is parsed. On macOS it is available as bcdUSB property.

Tested on ubuntu 24.04, Windows 11 and macOS 15.3.1