### PR TITLE
fix(macos): claiming incorrect interface

### DIFF
--- a/src/platform/macos_iokit/device.rs
+++ b/src/platform/macos_iokit/device.rs
@@ -245,7 +245,7 @@ impl MacDevice {
                     let current_number = get_integer_property(io_service, "bInterfaceNumber");
                     let found = current_number == Some(interface_number as i64);
                     debug!(
-                        "Looking for interface [n={interface_number}] to claim, examining interface [n={}]{}",
+                        "Looking for interface to claim [n={interface_number}], examining interface [n={}]{}",
                         current_number.map(|n| n.to_string()).unwrap_or_else(|| "unknown".to_string()),
                         found.then(|| " (found)").unwrap_or("")
                     );

--- a/src/platform/macos_iokit/device.rs
+++ b/src/platform/macos_iokit/device.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 use super::{
-    enumeration::{device_descriptor_from_fields, service_by_registry_id},
+    enumeration::{device_descriptor_from_fields, get_integer_property, service_by_registry_id},
     events::{add_event_source, EventRegistration},
     iokit::{call_iokit_function, check_iokit_return},
     iokit_c::IOUSBDevRequestTO,
@@ -241,7 +241,10 @@ impl MacDevice {
             let intf_service = self
                 .device
                 .create_interface_iterator()?
-                .find(|io_service| super::enumeration::get_integer_property(io_service, "bInterfaceNumber").map(|v| v as u8) == Some(interface_number))
+                .find(|io_service| {
+                    let current_number = get_integer_property(io_service, "bInterfaceNumber");
+                    current_number == Some(interface_number as i64)
+                })
                 .ok_or(Error::new(ErrorKind::NotFound, "interface not found"))?;
 
             let mut interface = IoKitInterface::new(intf_service)?;

--- a/src/platform/macos_iokit/device.rs
+++ b/src/platform/macos_iokit/device.rs
@@ -243,7 +243,13 @@ impl MacDevice {
                 .create_interface_iterator()?
                 .find(|io_service| {
                     let current_number = get_integer_property(io_service, "bInterfaceNumber");
-                    current_number == Some(interface_number as i64)
+                    let found = current_number == Some(interface_number as i64);
+                    debug!(
+                        "Looking for interface [n={interface_number}] to claim, examining interface [n={}]{}",
+                        current_number.map(|n| n.to_string()).unwrap_or_else(|| "unknown".to_string()),
+                        found.then(|| " (found)").unwrap_or("")
+                    );
+                    found
                 })
                 .ok_or(Error::new(ErrorKind::NotFound, "interface not found"))?;
 

--- a/src/platform/macos_iokit/device.rs
+++ b/src/platform/macos_iokit/device.rs
@@ -241,7 +241,7 @@ impl MacDevice {
             let intf_service = self
                 .device
                 .create_interface_iterator()?
-                .nth(interface_number as usize)
+                .find(|io_service| super::enumeration::get_integer_property(io_service, "bInterfaceNumber").map(|v| v as u8) == Some(interface_number))
                 .ok_or(Error::new(ErrorKind::NotFound, "interface not found"))?;
 
             let mut interface = IoKitInterface::new(intf_service)?;

--- a/src/platform/macos_iokit/enumeration.rs
+++ b/src/platform/macos_iokit/enumeration.rs
@@ -219,7 +219,7 @@ fn get_string_property(device: &IoService, property: &'static str) -> Option<Str
     get_property::<CFString>(device, property).map(|s| s.to_string())
 }
 
-fn get_integer_property(device: &IoService, property: &'static str) -> Option<i64> {
+pub fn get_integer_property(device: &IoService, property: &'static str) -> Option<i64> {
     let n = get_property::<CFNumber>(device, property)?;
     n.to_i64().or_else(|| {
         debug!("failed to convert {property} value {n:?} to i64");


### PR DESCRIPTION
Bug is exposed when a connected device has no continuous interface numbers. Then getting nth interface is different from getting interface of a specific number.

E.g. I have a device which has interfaces of numbers: 0, 1, 3, 4, 9. 
Number 2 is reserved for optional use (some variants of the device have this interface). Number 9 is for DFU interface. Space between 4 and 9 is for new functionalities.
Trying to claim interface 4 actually claimed interface 3, but I still was able to send control requests to interface 4. At the same time, another application (using libusb) has trouble to claim interface 3, because it has been already claimed by the first one using nusb.

This PR fixes this problem by getting and comparing `bInterfaceNumber` instead of using `nth` function on iterator.

logs from claiming the correct interface:
```
[2025-04-02T12:26:03Z DEBUG nusb::platform::macos_iokit::device] Looking for interface to claim [n=4], examining interface [n=0]
[2025-04-02T12:26:03Z DEBUG nusb::platform::macos_iokit::device] Looking for interface to claim [n=4], examining interface [n=1]
[2025-04-02T12:26:03Z DEBUG nusb::platform::macos_iokit::device] Looking for interface to claim [n=4], examining interface [n=3]
[2025-04-02T12:26:03Z DEBUG nusb::platform::macos_iokit::device] Looking for interface to claim [n=4], examining interface [n=4] (found)
```

Tested on macOS 15.3.1, MacBook Air with M1 chip.