### PR TITLE
Add cargo features for `smol` and `tokio` runtimes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        rust: ['stable', '1.76']
+        rust: ['stable', '1.79']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,11 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: |
+        cargo test --verbose
+        cargo test --verbose --features tokio
+        cargo test --verbose --features smol
+        cargo test --verbose --features smol,tokio
 
   build_android:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,16 @@ core-foundation-sys = "0.8.4"
 io-kit-sys = "0.4.0"
 
 [target.'cfg(any(target_os="linux", target_os="android", target_os="windows", target_os="macos"))'.dependencies]
-blocking ="1.6.1"
+blocking = { version = "1.6.1", optional = true }
+tokio = { version = "1", optional = true, features = ["rt"] }
+
+[features]
+# Use the `blocking` crate for making blocking IO async
+smol = ["dep:blocking"]
+
+# Use `tokio`'s IO threadpool for making blocking IO async
+tokio = ["dep:tokio"]
+
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Kevin Mehall <km@kevinmehall.net>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/kevinmehall/nusb"
-rust-version = "1.76" # keep in sync with .github/workflows/rust.yml
+rust-version = "1.79" # keep in sync with .github/workflows/rust.yml
 
 [dependencies]
 atomic-waker = "1.1.2"


### PR DESCRIPTION
https://github.com/kevinmehall/nusb/pull/100 added a dependency on `blocking` for running blocking syscalls on a threadpool. This extends that to allow choosing `blocking` (`smol`) or `tokio` via cargo features, also allowing omitting both if the affected methods don't need to be used asynchronously.

This increases the MSRV to 1.79: The associated type bounds feature, stabilized in 1.79 allows adding an implied Send bound on all IntoFuture types used with MaybeFuture, so every function doesn't have to be marked as Send. This is going to be especially useful with wasm, because it allows the Send bound to be turned on and off in one place.