### PR TITLE
[v0.1] fix(macos): claiming incorrect interface (#124)

### DIFF
--- a/src/platform/macos_iokit/device.rs
+++ b/src/platform/macos_iokit/device.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 use super::{
-    enumeration::service_by_registry_id,
+    enumeration::{get_integer_property, service_by_registry_id},
     events::EventRegistration,
     iokit::{call_iokit_function, check_iokit_return},
     iokit_c::IOUSBDevRequestTO,
@@ -203,7 +203,10 @@ impl MacDevice {
         let intf_service = self
             .device
             .create_interface_iterator()?
-            .nth(interface_number as usize)
+            .find(|io_service| {
+                let current_number = get_integer_property(io_service, "bInterfaceNumber");
+                current_number == Some(interface_number as i64)
+            })
             .ok_or(Error::new(ErrorKind::NotFound, "interface not found"))?;
 
         let mut interface = IoKitInterface::new(intf_service)?;

--- a/src/platform/macos_iokit/enumeration.rs
+++ b/src/platform/macos_iokit/enumeration.rs
@@ -130,7 +130,7 @@ fn get_string_property(device: &IoService, property: &'static str) -> Option<Str
     get_property::<CFString>(device, property).map(|s| s.to_string())
 }
 
-fn get_integer_property(device: &IoService, property: &'static str) -> Option<i64> {
+pub fn get_integer_property(device: &IoService, property: &'static str) -> Option<i64> {
     let n = get_property::<CFNumber>(device, property)?;
     n.to_i64().or_else(|| {
         debug!("failed to convert {property} value {n:?} to i64");


### PR DESCRIPTION
Backport of #124

* fix(macos): claiming interface on macOS treats interface number as index

Bug is exposed when connected device has not continuous interface numbers. Then getting nth interface is not the same as getting interface of specific number.