### PR TITLE
Define a new Error type instead of re-exporting std::io::Error

### DIFF
--- a/src/descriptors.rs
+++ b/src/descriptors.rs
@@ -2,17 +2,11 @@
 //!
 //! Descriptors are blocks of data that describe the functionality of a USB device.
 
-use std::{
-    collections::BTreeMap,
-    fmt::{Debug, Display},
-    iter,
-    num::NonZeroU8,
-    ops::Deref,
-};
+use std::{collections::BTreeMap, fmt::Debug, iter, num::NonZeroU8, ops::Deref};
 
 use log::warn;
 
-use crate::{transfer::Direction, Error};
+use crate::transfer::Direction;
 
 pub(crate) const DESCRIPTOR_TYPE_DEVICE: u8 = 0x01;
 pub(crate) const DESCRIPTOR_LEN_DEVICE: u8 = 18;
@@ -710,34 +704,6 @@ pub enum TransferType {
     Interrupt = 3,
 }
 
-/// Error from [`crate::Device::active_configuration`]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct ActiveConfigurationError {
-    pub(crate) configuration_value: u8,
-}
-
-impl Display for ActiveConfigurationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.configuration_value == 0 {
-            write!(f, "device is not configured")
-        } else {
-            write!(
-                f,
-                "no descriptor found for active configuration {}",
-                self.configuration_value
-            )
-        }
-    }
-}
-
-impl std::error::Error for ActiveConfigurationError {}
-
-impl From<ActiveConfigurationError> for Error {
-    fn from(value: ActiveConfigurationError) -> Self {
-        Error::other(value)
-    }
-}
-
 /// Split a chain of concatenated configuration descriptors by `wTotalLength`
 #[allow(unused)]
 pub(crate) fn parse_concatenated_config_descriptors(
@@ -914,7 +880,7 @@ fn test_linux_root_hub() {
 fn test_dell_webcam() {
     let c = ConfigurationDescriptor(&[
         0x09, 0x02, 0xa3, 0x02, 0x02, 0x01, 0x00, 0x80, 0xfa,
-        
+
         // unknown (skipped)
         0x28, 0xff, 0x42, 0x49, 0x53, 0x54, 0x00, 0x01, 0x06, 0x01, 0x10, 0x00,
         0x00, 0x00, 0x00, 0x00, 0xd1, 0x10, 0xd0, 0x07, 0xd2, 0x11, 0xf4, 0x01,

--- a/src/device.rs
+++ b/src/device.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 use log::{error, warn};
 use std::{
+    fmt::Debug,
     future::{poll_fn, Future},
     marker::PhantomData,
     num::NonZeroU8,
@@ -346,6 +347,12 @@ impl Device {
     }
 }
 
+impl Debug for Device {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Device").finish()
+    }
+}
+
 /// An opened interface of a USB device.
 ///
 /// Obtain an `Interface` with the [`Device::claim_interface`] method.
@@ -521,6 +528,14 @@ impl Interface {
     }
 }
 
+impl Debug for Interface {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Interface")
+            .field("number", &self.backend.interface_number)
+            .finish()
+    }
+}
+
 /// Exclusive access to an endpoint of a USB device.
 ///
 /// Obtain an `Endpoint` with the [`Interface::endpoint`] method.
@@ -690,6 +705,19 @@ impl<EpType: BulkOrInterrupt, Dir: EndpointDirection> Endpoint<EpType, Dir> {
     /// This should not be called when transfers are pending on the endpoint.
     pub fn clear_halt(&mut self) -> impl MaybeFuture<Output = Result<(), Error>> {
         self.backend.clear_halt()
+    }
+}
+
+impl<EpType: BulkOrInterrupt, Dir: EndpointDirection> Debug for Endpoint<EpType, Dir> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Endpoint")
+            .field(
+                "address",
+                &format_args!("0x{:02x}", self.endpoint_address()),
+            )
+            .field("type", &EpType::TYPE)
+            .field("direction", &Dir::DIR)
+            .finish()
     }
 }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,19 +1,18 @@
 use crate::{
     descriptors::{
-        decode_string_descriptor, validate_string_descriptor, ActiveConfigurationError,
-        ConfigurationDescriptor, DeviceDescriptor, InterfaceDescriptor, DESCRIPTOR_TYPE_STRING,
+        decode_string_descriptor, validate_string_descriptor, ConfigurationDescriptor,
+        DeviceDescriptor, InterfaceDescriptor, DESCRIPTOR_TYPE_STRING,
     },
     platform,
     transfer::{
         Buffer, BulkOrInterrupt, Completion, ControlIn, ControlOut, Direction, EndpointDirection,
         EndpointType, TransferError,
     },
-    DeviceInfo, Error, MaybeFuture, Speed,
+    ActiveConfigurationError, DeviceInfo, Error, ErrorKind, GetDescriptorError, MaybeFuture, Speed,
 };
 use log::{error, warn};
 use std::{
     future::{poll_fn, Future},
-    io::ErrorKind,
     marker::PhantomData,
     num::NonZeroU8,
     sync::Arc,
@@ -51,9 +50,7 @@ impl Device {
         Device { backend }
     }
 
-    pub(crate) fn open(
-        d: &DeviceInfo,
-    ) -> impl MaybeFuture<Output = Result<Device, std::io::Error>> {
+    pub(crate) fn open(d: &DeviceInfo) -> impl MaybeFuture<Output = Result<Device, Error>> {
         platform::Device::from_device_info(d).map(|d| d.map(Device::wrap))
     }
 
@@ -181,13 +178,14 @@ impl Device {
         desc_index: u8,
         language_id: u16,
         timeout: Duration,
-    ) -> impl MaybeFuture<Output = Result<Vec<u8>, Error>> {
+    ) -> impl MaybeFuture<Output = Result<Vec<u8>, GetDescriptorError>> {
         #[cfg(target_os = "windows")]
         {
             let _ = timeout;
             self.backend
                 .clone()
                 .get_descriptor(desc_type, desc_index, language_id)
+                .map(|r| r.map_err(GetDescriptorError::Transfer))
         }
 
         #[cfg(not(target_os = "windows"))]
@@ -206,7 +204,7 @@ impl Device {
                 },
                 timeout,
             )
-            .map(|r| Ok(r?))
+            .map(|r| r.map_err(GetDescriptorError::Transfer))
         }
     }
 
@@ -218,16 +216,13 @@ impl Device {
     pub fn get_string_descriptor_supported_languages(
         &self,
         timeout: Duration,
-    ) -> impl MaybeFuture<Output = Result<impl Iterator<Item = u16>, Error>> {
+    ) -> impl MaybeFuture<Output = Result<impl Iterator<Item = u16>, GetDescriptorError>> {
         self.get_descriptor(DESCRIPTOR_TYPE_STRING, 0, 0, timeout)
             .map(move |r| {
                 let data = r?;
                 if !validate_string_descriptor(&data) {
                     error!("String descriptor language list read {data:?}, not a valid string descriptor");
-                    return Err(Error::new(
-                        ErrorKind::InvalidData,
-                        "string descriptor data was invalid",
-                    ));
+                    return Err(GetDescriptorError::InvalidDescriptor)
                 }
 
                 //TODO: Use array_chunks once stable
@@ -252,7 +247,7 @@ impl Device {
         desc_index: NonZeroU8,
         language_id: u16,
         timeout: Duration,
-    ) -> impl MaybeFuture<Output = Result<String, Error>> {
+    ) -> impl MaybeFuture<Output = Result<String, GetDescriptorError>> {
         self.get_descriptor(
             DESCRIPTOR_TYPE_STRING,
             desc_index.get(),
@@ -261,9 +256,7 @@ impl Device {
         )
         .map(|r| {
             let data = r?;
-            decode_string_descriptor(&data).map_err(|_| {
-                Error::new(ErrorKind::InvalidData, "string descriptor data was invalid")
-            })
+            decode_string_descriptor(&data).map_err(|_| GetDescriptorError::InvalidDescriptor)
         })
     }
 
@@ -500,16 +493,23 @@ impl Interface {
     pub fn endpoint<EpType: EndpointType, Dir: EndpointDirection>(
         &self,
         address: u8,
-    ) -> Result<Endpoint<EpType, Dir>, ClaimEndpointError> {
+    ) -> Result<Endpoint<EpType, Dir>, Error> {
         let intf_desc = self.descriptor();
         let ep_desc =
             intf_desc.and_then(|desc| desc.endpoints().find(|ep| ep.address() == address));
         let Some(ep_desc) = ep_desc else {
-            return Err(ClaimEndpointError::InvalidAddress);
+            return Err(Error::new(
+                ErrorKind::NotFound,
+                "specified endpoint does not exist on this interface",
+            ));
         };
 
-        if ep_desc.transfer_type() != EpType::TYPE || address & Direction::MASK != Dir::DIR as u8 {
-            return Err(ClaimEndpointError::InvalidType);
+        if address & Direction::MASK != Dir::DIR as u8 {
+            return Err(Error::new(ErrorKind::Other, "incorrect endpoint direction"));
+        }
+
+        if ep_desc.transfer_type() != EpType::TYPE {
+            return Err(Error::new(ErrorKind::Other, "incorrect endpoint type"));
         }
 
         let backend = self.backend.endpoint(ep_desc)?;
@@ -520,32 +520,6 @@ impl Interface {
         })
     }
 }
-
-/// Error from [`Interface::endpoint`].
-#[non_exhaustive]
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ClaimEndpointError {
-    /// The specified address does not exist on this interface and alternate setting
-    InvalidAddress,
-
-    /// The type or direction does not match the endpoint descriptor for this address
-    InvalidType,
-
-    /// The endpoint is already claimed
-    Busy,
-}
-
-impl std::fmt::Display for ClaimEndpointError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ClaimEndpointError::InvalidAddress => write!(f, "invalid endpoint address"),
-            ClaimEndpointError::InvalidType => write!(f, "incorrect endpoint type or direction"),
-            ClaimEndpointError::Busy => write!(f, "endpoint is already claimed"),
-        }
-    }
-}
-
-impl std::error::Error for ClaimEndpointError {}
 
 /// Exclusive access to an endpoint of a USB device.
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,169 @@
+use std::{fmt::Display, io, num::NonZeroU32};
+
+use crate::{platform::format_os_error_code, transfer::TransferError};
+
+/// Error returned from `nusb` operations other than transfers.
+#[derive(Debug, Clone)]
+pub struct Error {
+    pub(crate) kind: ErrorKind,
+    pub(crate) code: Option<NonZeroU32>,
+    pub(crate) message: &'static str,
+}
+
+impl Error {
+    pub(crate) fn new(kind: ErrorKind, message: &'static str) -> Self {
+        Self {
+            kind,
+            code: None,
+            message,
+        }
+    }
+
+    #[track_caller]
+    pub(crate) fn log_error(self) -> Self {
+        log::error!("{}", self);
+        self
+    }
+
+    #[track_caller]
+    pub(crate) fn log_debug(self) -> Self {
+        log::debug!("{}", self);
+        self
+    }
+
+    /// Get the error kind.
+    pub fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+
+    /// Get the error code from the OS, if applicable.
+    ///
+    /// * On Linux this is the `errno` value.
+    /// * On Windows this is the `WIN32_ERROR` value.
+    /// * On macOS this is the `IOReturn` value.
+    pub fn os_error(&self) -> Option<u32> {
+        self.code.map(|c| c.get())
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)?;
+        if let Some(code) = self.code {
+            write!(f, " (")?;
+            format_os_error_code(f, code.get())?;
+            write!(f, ")")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<Error> for io::Error {
+    fn from(err: Error) -> Self {
+        let kind = match err.kind {
+            ErrorKind::Disconnected => io::ErrorKind::NotConnected,
+            ErrorKind::Busy => io::ErrorKind::Other, // TODO: ResourceBusy
+            ErrorKind::PermissionDenied => io::ErrorKind::PermissionDenied,
+            ErrorKind::NotFound => io::ErrorKind::NotFound,
+            ErrorKind::Unsupported => io::ErrorKind::Unsupported,
+            ErrorKind::Other => io::ErrorKind::Other,
+        };
+        io::Error::new(kind, err)
+    }
+}
+
+/// General category of error as part of an [`Error`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ErrorKind {
+    /// Device is disconnected.
+    Disconnected,
+
+    /// Device, interface, or endpoint is in use by another application, kernel driver, or handle.
+    Busy,
+
+    /// This user or application does not have permission to perform the requested operation.
+    PermissionDenied,
+
+    /// Requested configuration, interface, or alternate setting not found
+    NotFound,
+
+    /// The requested operation is not supported by the platform or its currently-configured driver.
+    Unsupported,
+
+    /// Uncategorized error.
+    Other,
+}
+
+/// Error from [`crate::Device::active_configuration`]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct ActiveConfigurationError {
+    pub(crate) configuration_value: u8,
+}
+
+impl Display for ActiveConfigurationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.configuration_value == 0 {
+            write!(f, "device is not configured")
+        } else {
+            write!(
+                f,
+                "no descriptor found for active configuration {}",
+                self.configuration_value
+            )
+        }
+    }
+}
+
+impl std::error::Error for ActiveConfigurationError {}
+
+impl From<ActiveConfigurationError> for Error {
+    fn from(value: ActiveConfigurationError) -> Self {
+        let message = if value.configuration_value == 0 {
+            "device is not configured"
+        } else {
+            "no descriptor found for active configuration"
+        };
+        Error::new(ErrorKind::Other, message)
+    }
+}
+
+impl From<ActiveConfigurationError> for std::io::Error {
+    fn from(value: ActiveConfigurationError) -> Self {
+        std::io::Error::other(value)
+    }
+}
+
+/// Error for descriptor reads.
+#[derive(Debug, Copy, Clone)]
+pub enum GetDescriptorError {
+    /// Transfer error when getting the descriptor.
+    Transfer(TransferError),
+
+    /// Invalid descriptor data
+    InvalidDescriptor,
+}
+
+impl Display for GetDescriptorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GetDescriptorError::Transfer(e) => write!(f, "{}", e),
+            GetDescriptorError::InvalidDescriptor => write!(f, "invalid descriptor"),
+        }
+    }
+}
+
+impl std::error::Error for GetDescriptorError {}
+
+impl From<GetDescriptorError> for std::io::Error {
+    fn from(value: GetDescriptorError) -> Self {
+        match value {
+            GetDescriptorError::Transfer(e) => e.into(),
+            GetDescriptorError::InvalidDescriptor => {
+                std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid descriptor")
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,8 +134,6 @@
 //! These features do not affect and are not required for transfers, which are
 //! implemented on top of natively-async OS APIs.
 
-use std::io;
-
 mod platform;
 
 pub mod descriptors;
@@ -143,7 +141,7 @@ mod enumeration;
 pub use enumeration::{BusInfo, DeviceId, DeviceInfo, InterfaceInfo, Speed, UsbControllerType};
 
 mod device;
-pub use device::{ClaimEndpointError, Device, Endpoint, Interface};
+pub use device::{Device, Endpoint, Interface};
 
 pub mod transfer;
 
@@ -154,8 +152,8 @@ pub use maybe_future::MaybeFuture;
 
 mod bitset;
 
-/// OS error returned from operations other than transfers.
-pub type Error = io::Error;
+mod error;
+pub use error::{ActiveConfigurationError, Error, ErrorKind, GetDescriptorError};
 
 /// Get an iterator listing the connected devices.
 ///

--- a/src/platform/linux_usbfs/device.rs
+++ b/src/platform/linux_usbfs/device.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{BTreeMap, VecDeque},
     ffi::c_void,
     fs::File,
-    io::{ErrorKind, Read, Seek},
+    io::{Read, Seek},
     mem::ManuallyDrop,
     path::PathBuf,
     sync::{
@@ -34,7 +34,6 @@ use crate::{
         parse_concatenated_config_descriptors, ConfigurationDescriptor, DeviceDescriptor,
         EndpointDescriptor, TransferType, DESCRIPTOR_LEN_DEVICE,
     },
-    device::ClaimEndpointError,
     maybe_future::{blocking::Blocking, MaybeFuture},
     transfer::{
         internal::{
@@ -43,7 +42,7 @@ use crate::{
         request_type, Buffer, Completion, ControlIn, ControlOut, ControlType, Direction, Recipient,
         TransferError,
     },
-    DeviceInfo, Error, Speed,
+    DeviceInfo, Error, ErrorKind, Speed,
 };
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
@@ -82,7 +81,19 @@ impl LinuxDevice {
         Blocking::new(move || {
             let path = PathBuf::from(format!("/dev/bus/usb/{busnum:03}/{devnum:03}"));
             let fd = rustix::fs::open(&path, OFlags::RDWR | OFlags::CLOEXEC, Mode::empty())
-                .inspect_err(|e| warn!("Failed to open device {path:?}: {e}"))?;
+                .map_err(|e| {
+                    match e {
+                        Errno::NOENT => {
+                            Error::new_os(ErrorKind::Disconnected, "device not found", e)
+                        }
+                        Errno::PERM => {
+                            Error::new_os(ErrorKind::PermissionDenied, "permission denied", e)
+                        }
+                        e => Error::new_os(ErrorKind::Other, "failed to open device", e),
+                    }
+                    .log_debug()
+                })?;
+
             Self::create_inner(fd, Some(sysfs_path))
         })
     }
@@ -100,18 +111,18 @@ impl LinuxDevice {
         fd: OwnedFd,
         sysfs: Option<SysfsPath>,
     ) -> Result<Arc<LinuxDevice>, Error> {
-        let descriptors = read_all_from_fd(&fd)?;
+        let descriptors = read_all_from_fd(&fd).map_err(|e| {
+            Error::new_io(ErrorKind::Other, "failed to read descriptors", e).log_error()
+        })?;
 
         let Some(_) = DeviceDescriptor::new(&descriptors) else {
-            return Err(Error::new(
-                ErrorKind::InvalidData,
-                "invalid device descriptor",
-            ));
+            return Err(Error::new(ErrorKind::Other, "invalid device descriptor"));
         };
 
         let active_config: u8 = if let Some(sysfs) = sysfs.as_ref() {
-            sysfs.read_attr("bConfigurationValue").inspect_err(|e| {
+            sysfs.read_attr("bConfigurationValue").map_err(|e| {
                 warn!("failed to read sysfs bConfigurationValue: {e}");
+                Error::new(ErrorKind::Other, "failed to read sysfs bConfigurationValue")
             })?
         } else {
             request_configuration(&fd).unwrap_or_else(|()| {
@@ -132,7 +143,7 @@ impl LinuxDevice {
             rustix::time::TimerfdClockId::Monotonic,
             TimerfdFlags::CLOEXEC | TimerfdFlags::NONBLOCK,
         )
-        .inspect_err(|e| log::error!("Failed to create timerfd: {e}"))?;
+        .map_err(|e| Error::new_os(ErrorKind::Other, "failed to create timerfd", e).log_error())?;
 
         let arc = Arc::new_cyclic(|weak| {
             let events_id = DEVICES.lock().unwrap().insert(weak.clone());
@@ -313,7 +324,12 @@ impl LinuxDevice {
         configuration: u8,
     ) -> impl MaybeFuture<Output = Result<(), Error>> {
         Blocking::new(move || {
-            usbfs::set_configuration(&self.fd, configuration)?;
+            usbfs::set_configuration(&self.fd, configuration).map_err(|e| match e {
+                Errno::INVAL => Error::new_os(ErrorKind::NotFound, "configuration not found", e),
+                Errno::BUSY => Error::new_os(ErrorKind::Busy, "device is busy", e),
+                Errno::NODEV => Error::new_os(ErrorKind::Disconnected, "device disconnected", e),
+                _ => Error::new_os(ErrorKind::Other, "failed to set configuration", e),
+            })?;
             self.active_config.store(configuration, Ordering::SeqCst);
             Ok(())
         })
@@ -321,8 +337,11 @@ impl LinuxDevice {
 
     pub(crate) fn reset(self: Arc<Self>) -> impl MaybeFuture<Output = Result<(), Error>> {
         Blocking::new(move || {
-            usbfs::reset(&self.fd)?;
-            Ok(())
+            usbfs::reset(&self.fd).map_err(|e| match e {
+                Errno::BUSY => Error::new_os(ErrorKind::Busy, "device is busy", e),
+                Errno::NODEV => Error::new_os(ErrorKind::Disconnected, "device disconnected", e),
+                _ => Error::new_os(ErrorKind::Other, "failed to reset device", e),
+            })
         })
     }
 
@@ -352,27 +371,40 @@ impl LinuxDevice {
         })
     }
 
+    fn handle_claim_interface_result(
+        self: Arc<Self>,
+        interface_number: u8,
+        result: Result<(), Errno>,
+        reattach: bool,
+    ) -> Result<Arc<LinuxInterface>, Error> {
+        result.map_err(|e| {
+            match e {
+                Errno::INVAL => Error::new_os(ErrorKind::NotFound, "interface not found", e),
+                Errno::BUSY => Error::new_os(ErrorKind::Busy, "interface is busy", e),
+                Errno::NODEV => Error::new_os(ErrorKind::Disconnected, "device disconnected", e),
+                _ => Error::new_os(ErrorKind::Other, "failed to claim interface", e),
+            }
+            .log_error()
+        })?;
+        debug!(
+            "Claimed interface {interface_number} on device id {dev}",
+            dev = self.events_id
+        );
+        Ok(Arc::new(LinuxInterface {
+            device: self,
+            interface_number,
+            reattach,
+            state: Mutex::new(Default::default()),
+        }))
+    }
+
     pub(crate) fn claim_interface(
         self: Arc<Self>,
         interface_number: u8,
     ) -> impl MaybeFuture<Output = Result<Arc<LinuxInterface>, Error>> {
         Blocking::new(move || {
-            usbfs::claim_interface(&self.fd, interface_number).inspect_err(|e| {
-                warn!(
-                    "Failed to claim interface {interface_number} on device id {dev}: {e}",
-                    dev = self.events_id
-                )
-            })?;
-            debug!(
-                "Claimed interface {interface_number} on device id {dev}",
-                dev = self.events_id
-            );
-            Ok(Arc::new(LinuxInterface {
-                device: self,
-                interface_number,
-                reattach: false,
-                state: Mutex::new(Default::default()),
-            }))
+            let result = usbfs::claim_interface(&self.fd, interface_number);
+            self.handle_claim_interface_result(interface_number, result, false)
         })
     }
 
@@ -381,17 +413,8 @@ impl LinuxDevice {
         interface_number: u8,
     ) -> impl MaybeFuture<Output = Result<Arc<LinuxInterface>, Error>> {
         Blocking::new(move || {
-            usbfs::detach_and_claim_interface(&self.fd, interface_number)?;
-            debug!(
-                "Detached and claimed interface {interface_number} on device id {dev}",
-                dev = self.events_id
-            );
-            Ok(Arc::new(LinuxInterface {
-                device: self,
-                interface_number,
-                reattach: true,
-                state: Mutex::new(Default::default()),
-            }))
+            let result = usbfs::detach_and_claim_interface(&self.fd, interface_number);
+            self.handle_claim_interface_result(interface_number, result, true)
         })
     }
 
@@ -400,7 +423,12 @@ impl LinuxDevice {
         self: &Arc<Self>,
         interface_number: u8,
     ) -> Result<(), Error> {
-        usbfs::detach_kernel_driver(&self.fd, interface_number).map_err(|e| e.into())
+        usbfs::detach_kernel_driver(&self.fd, interface_number).map_err(|e| match e {
+            Errno::INVAL => Error::new_os(ErrorKind::NotFound, "interface not found", e),
+            Errno::NODEV => Error::new_os(ErrorKind::Disconnected, "device disconnected", e),
+            Errno::NODATA => Error::new_os(ErrorKind::Other, "no kernel driver attached", e),
+            _ => Error::new_os(ErrorKind::Other, "failed to detach kernel driver", e),
+        })
     }
 
     #[cfg(target_os = "linux")]
@@ -408,7 +436,12 @@ impl LinuxDevice {
         self: &Arc<Self>,
         interface_number: u8,
     ) -> Result<(), Error> {
-        usbfs::attach_kernel_driver(&self.fd, interface_number).map_err(|e| e.into())
+        usbfs::attach_kernel_driver(&self.fd, interface_number).map_err(|e| match e {
+            Errno::INVAL => Error::new_os(ErrorKind::NotFound, "interface not found", e),
+            Errno::NODEV => Error::new_os(ErrorKind::Disconnected, "device disconnected", e),
+            Errno::BUSY => Error::new_os(ErrorKind::Busy, "kernel driver already attached", e),
+            _ => Error::new_os(ErrorKind::Other, "failed to attach kernel driver", e),
+        })
     }
 
     pub(crate) fn submit(&self, transfer: Idle<TransferData>) -> Pending<TransferData> {
@@ -583,16 +616,26 @@ impl LinuxInterface {
         Blocking::new(move || {
             let mut state = self.state.lock().unwrap();
             if !state.endpoints.is_empty() {
-                // TODO: Use ErrorKind::ResourceBusy once compatible with MSRV
-                return Err(Error::other(
-                    "must drop endpoints before changing alt setting",
+                return Err(Error::new(
+                    ErrorKind::Busy,
+                    "can't change alternate setting while endpoints are in use",
                 ));
             }
+            usbfs::set_interface(&self.device.fd, self.interface_number, alt_setting).map_err(
+                |e| match e {
+                    Errno::INVAL => {
+                        Error::new_os(ErrorKind::NotFound, "alternate setting not found", e)
+                    }
+                    Errno::NODEV => {
+                        Error::new_os(ErrorKind::Disconnected, "device disconnected", e)
+                    }
+                    _ => Error::new_os(ErrorKind::Other, "failed to set alternate setting", e),
+                },
+            )?;
             debug!(
                 "Set interface {} alt setting to {alt_setting}",
                 self.interface_number
             );
-            usbfs::set_interface(&self.device.fd, self.interface_number, alt_setting)?;
             state.alt_setting = alt_setting;
             Ok(())
         })
@@ -601,7 +644,7 @@ impl LinuxInterface {
     pub fn endpoint(
         self: &Arc<Self>,
         descriptor: EndpointDescriptor,
-    ) -> Result<LinuxEndpoint, ClaimEndpointError> {
+    ) -> Result<LinuxEndpoint, Error> {
         let address = descriptor.address();
         let ep_type = descriptor.transfer_type();
         let max_packet_size = descriptor.max_packet_size();
@@ -609,7 +652,7 @@ impl LinuxInterface {
         let mut state = self.state.lock().unwrap();
 
         if state.endpoints.is_set(address) {
-            return Err(ClaimEndpointError::Busy);
+            return Err(Error::new(ErrorKind::Busy, "endpoint already in use"));
         }
         state.endpoints.set(address);
 
@@ -730,7 +773,10 @@ impl LinuxEndpoint {
         Blocking::new(move || {
             let endpoint = inner.address;
             debug!("Clear halt, endpoint {endpoint:02x}");
-            Ok(usbfs::clear_halt(&inner.interface.device.fd, endpoint)?)
+            usbfs::clear_halt(&inner.interface.device.fd, endpoint).map_err(|e| match e {
+                Errno::NODEV => Error::new_os(ErrorKind::Disconnected, "device disconnected", e),
+                _ => Error::new_os(ErrorKind::Other, "failed to clear halt", e),
+            })
         })
     }
 

--- a/src/platform/macos_iokit/hotplug.rs
+++ b/src/platform/macos_iokit/hotplug.rs
@@ -18,7 +18,7 @@ use io_kit_sys::{
 use log::debug;
 use slab::Slab;
 
-use crate::{hotplug::HotplugEvent, DeviceId, Error};
+use crate::{hotplug::HotplugEvent, DeviceId, Error, ErrorKind};
 
 use super::{
     enumeration::{get_registry_id, probe_device},
@@ -79,7 +79,7 @@ impl MacHotplugWatch {
         let dictionary = unsafe {
             let d = IOServiceMatching(kIOUSBDeviceClassName);
             if d.is_null() {
-                return Err(Error::other("IOServiceMatching failed"));
+                return Err(Error::new(ErrorKind::Other, "IOServiceMatching failed"));
             }
             CFDictionary::wrap_under_create_rule(d)
         };
@@ -162,7 +162,9 @@ fn register_notification(
         );
 
         if r != kIOReturnSuccess {
-            return Err(Error::other("Failed to register notification"));
+            return Err(
+                Error::new_os(ErrorKind::Other, "failed to register notification", r).log_error(),
+            );
         }
         let mut iter = IoServiceIterator::new(iter);
 

--- a/src/platform/macos_iokit/iokit.rs
+++ b/src/platform/macos_iokit/iokit.rs
@@ -5,9 +5,6 @@
 
 use core_foundation_sys::uuid::CFUUIDBytes;
 use io_kit_sys::{ret::IOReturn, IOIteratorNext, IOObjectRelease};
-use std::io::ErrorKind;
-
-use crate::Error;
 
 use super::iokit_c::{self, CFUUIDGetUUIDBytes, IOCFPlugInInterface};
 
@@ -117,15 +114,9 @@ pub(crate) fn usb_interface_type_id() -> CFUUIDBytes {
     unsafe { CFUUIDGetUUIDBytes(iokit_c::kIOUSBInterfaceInterfaceID500()) }
 }
 
-pub(crate) fn check_iokit_return(r: IOReturn) -> Result<(), Error> {
-    #[allow(non_upper_case_globals)]
-    #[deny(unreachable_patterns)]
+pub(crate) fn check_iokit_return(r: IOReturn) -> Result<(), IOReturn> {
     match r {
         io_kit_sys::ret::kIOReturnSuccess => Ok(()),
-        io_kit_sys::ret::kIOReturnExclusiveAccess => {
-            Err(Error::other("could not be opened for exclusive access"))
-        }
-        io_kit_sys::ret::kIOReturnNotFound => Err(Error::new(ErrorKind::NotFound, "not found")),
-        _ => Err(Error::from_raw_os_error(r)),
+        e => Err(e),
     }
 }

--- a/src/platform/macos_iokit/mod.rs
+++ b/src/platform/macos_iokit/mod.rs
@@ -1,4 +1,7 @@
+use std::num::NonZeroU32;
+
 use crate::transfer::TransferError;
+use crate::ErrorKind;
 
 mod transfer;
 use io_kit_sys::ret::IOReturn;
@@ -35,5 +38,19 @@ fn status_to_transfer_result(status: IOReturn) -> Result<(), TransferError> {
         iokit_c::kIOUSBPipeStalled => Err(TransferError::Stall),
         io_kit_sys::ret::kIOReturnBadArgument => Err(TransferError::InvalidArgument), // used for `submit_err`
         _ => Err(TransferError::Unknown(status as u32)),
+    }
+}
+
+pub fn format_os_error_code(f: &mut std::fmt::Formatter<'_>, code: u32) -> std::fmt::Result {
+    write!(f, "error 0x{:08x}", code)
+}
+
+impl crate::error::Error {
+    pub(crate) fn new_os(kind: ErrorKind, message: &'static str, code: IOReturn) -> Self {
+        Self {
+            kind,
+            code: NonZeroU32::new(code as u32),
+            message,
+        }
     }
 }

--- a/src/platform/windows_winusb/hotplug.rs
+++ b/src/platform/windows_winusb/hotplug.rs
@@ -7,7 +7,7 @@ use std::{
     task::{Context, Poll, Waker},
 };
 
-use log::{debug, error};
+use log::debug;
 use windows_sys::Win32::{
     Devices::{
         DeviceAndDriverInstallation::{
@@ -78,8 +78,12 @@ impl WindowsHotplugWatch {
         };
 
         if cr != CR_SUCCESS {
-            error!("CM_Register_Notification failed: {cr}");
-            return Err(Error::other("Failed to initialize hotplug notifications"));
+            return Err(Error::new_os(
+                crate::ErrorKind::Other,
+                "failed to initialize hotplug notifications",
+                cr,
+            )
+            .log_error());
         }
 
         Ok(WindowsHotplugWatch {

--- a/src/platform/windows_winusb/mod.rs
+++ b/src/platform/windows_winusb/mod.rs
@@ -1,4 +1,6 @@
 mod enumeration;
+use std::num::NonZeroU32;
+
 pub use enumeration::{list_buses, list_devices};
 
 mod events;
@@ -14,7 +16,24 @@ mod cfgmgr32;
 mod hub;
 mod registry;
 pub(crate) use cfgmgr32::DevInst;
+use windows_sys::Win32::Foundation::WIN32_ERROR;
 pub(crate) use DevInst as DeviceId;
 mod hotplug;
 mod util;
 pub(crate) use hotplug::WindowsHotplugWatch as HotplugWatch;
+
+use crate::ErrorKind;
+
+pub fn format_os_error_code(f: &mut std::fmt::Formatter<'_>, code: u32) -> std::fmt::Result {
+    write!(f, "error {}", code)
+}
+
+impl crate::error::Error {
+    pub(crate) fn new_os(kind: ErrorKind, message: &'static str, code: WIN32_ERROR) -> Self {
+        Self {
+            kind,
+            code: NonZeroU32::new(code as u32),
+            message,
+        }
+    }
+}

--- a/src/platform/windows_winusb/util.rs
+++ b/src/platform/windows_winusb/util.rs
@@ -2,7 +2,6 @@ use std::{
     borrow::Borrow,
     ffi::{OsStr, OsString},
     fmt::{Display, Write},
-    io,
     ops::Deref,
     os::windows::prelude::{
         AsHandle, AsRawHandle, HandleOrInvalid, OsStrExt, OsStringExt, OwnedHandle, RawHandle,
@@ -12,14 +11,14 @@ use std::{
 };
 
 use windows_sys::Win32::{
-    Foundation::{GENERIC_READ, GENERIC_WRITE, HANDLE},
+    Foundation::{GetLastError, GENERIC_READ, GENERIC_WRITE, HANDLE, WIN32_ERROR},
     Storage::FileSystem::{
         CreateFileW, FILE_FLAG_OVERLAPPED, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
     },
 };
 
 /// Wrapper around `CreateFile`
-pub fn create_file(path: &WCStr) -> Result<OwnedHandle, io::Error> {
+pub fn create_file(path: &WCStr) -> Result<OwnedHandle, WIN32_ERROR> {
     unsafe {
         let r = CreateFileW(
             path.as_ptr(),
@@ -32,7 +31,7 @@ pub fn create_file(path: &WCStr) -> Result<OwnedHandle, io::Error> {
         );
         HandleOrInvalid::from_raw_handle(r as RawHandle)
             .try_into()
-            .map_err(|_| io::Error::last_os_error())
+            .map_err(|_| GetLastError())
     }
 }
 

--- a/src/transfer/mod.rs
+++ b/src/transfer/mod.rs
@@ -16,7 +16,7 @@ pub use buffer::Buffer;
 
 pub(crate) mod internal;
 
-use crate::descriptors::TransferType;
+use crate::{descriptors::TransferType, platform};
 
 /// Transfer error.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -60,11 +60,9 @@ impl Display for TransferError {
             TransferError::Fault => write!(f, "hardware fault or protocol violation"),
             TransferError::InvalidArgument => write!(f, "invalid or unsupported argument"),
             TransferError::Unknown(e) => {
-                if cfg!(target_os = "macos") {
-                    write!(f, "unknown error (0x{e:08x})")
-                } else {
-                    write!(f, "unknown error ({e})")
-                }
+                write!(f, "unknown (")?;
+                platform::format_os_error_code(f, *e)?;
+                write!(f, ")")
             }
         }
     }


### PR DESCRIPTION
The default mapping from OS error codes to io::Error's messages is often wrong
or misleading. We can do a lot better, but it takes a lot of error-handling code.