### PR TITLE
windows: Always use interface descriptors rather than child device nodes for InterfaceInfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rustix = { version = "1.0.1", features = ["fs", "event", "net", "time", "mm"] }
 linux-raw-sys = { version = "0.9.2", features = ["ioctl"] }
 
 [target.'cfg(target_os="windows")'.dependencies]
-windows-sys = { version = "0.59.0", features = ["Win32_Devices_Usb", "Win32_Devices_DeviceAndDriverInstallation", "Win32_Foundation", "Win32_Devices_Properties", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System_IO", "Win32_System_Registry", "Win32_System_Com"] }
+windows-sys = { version = "0.60.2", features = ["Win32_Devices_Usb", "Win32_Devices_DeviceAndDriverInstallation", "Win32_Foundation", "Win32_Devices_Properties", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System_IO", "Win32_System_Registry", "Win32_System_Com"] }
 
 [target.'cfg(target_os="macos")'.dependencies]
 core-foundation = "0.10.1"

--- a/src/platform/windows_winusb/cfgmgr32.rs
+++ b/src/platform/windows_winusb/cfgmgr32.rs
@@ -13,11 +13,11 @@ use windows_sys::{
                 CM_LOCATE_DEVNODE_PHANTOM, CM_REGISTRY_HARDWARE, CR_BUFFER_SMALL, CR_SUCCESS,
             },
             Properties::{
-                DEVPKEY_Device_InstanceId, DEVPROPKEY, DEVPROPTYPE, DEVPROP_TYPE_STRING,
+                DEVPKEY_Device_InstanceId, DEVPROPTYPE, DEVPROP_TYPE_STRING,
                 DEVPROP_TYPE_STRING_LIST, DEVPROP_TYPE_UINT32,
             },
         },
-        Foundation::INVALID_HANDLE_VALUE,
+        Foundation::{DEVPROPKEY, INVALID_HANDLE_VALUE},
         System::Registry::KEY_READ,
     },
 };

--- a/src/platform/windows_winusb/hotplug.rs
+++ b/src/platform/windows_winusb/hotplug.rs
@@ -13,7 +13,7 @@ use windows_sys::Win32::{
         DeviceAndDriverInstallation::{
             CM_Register_Notification, CM_Unregister_Notification, CM_NOTIFY_ACTION,
             CM_NOTIFY_ACTION_DEVICEINTERFACEARRIVAL, CM_NOTIFY_ACTION_DEVICEINTERFACEREMOVAL,
-            CM_NOTIFY_EVENT_DATA, CM_NOTIFY_FILTER, CM_NOTIFY_FILTER_0, CM_NOTIFY_FILTER_0_2,
+            CM_NOTIFY_EVENT_DATA, CM_NOTIFY_FILTER, CM_NOTIFY_FILTER_0, CM_NOTIFY_FILTER_0_0,
             CM_NOTIFY_FILTER_TYPE_DEVICEINTERFACE, CR_SUCCESS, HCMNOTIFICATION,
         },
         Properties::DEVPKEY_Device_InstanceId,
@@ -62,7 +62,7 @@ impl WindowsHotplugWatch {
             FilterType: CM_NOTIFY_FILTER_TYPE_DEVICEINTERFACE,
             Reserved: 0,
             u: CM_NOTIFY_FILTER_0 {
-                DeviceInterface: CM_NOTIFY_FILTER_0_2 {
+                DeviceInterface: CM_NOTIFY_FILTER_0_0 {
                     ClassGuid: GUID_DEVINTERFACE_USB_DEVICE,
                 },
             },


### PR DESCRIPTION
For usbccgp devices, nusb collected InterfaceInfo data from the properties of child device nodes, while for other devices it read and parsed the cached configuration descriptor. This changes to doing the latter for all devices, but still iterates usbccgp child nodes to populate cached interface strings when available.

This fixes InterfaceInfo missing interfaces below IADs (which do not have their own device nodes), and means that we should at least have class/subclass/protocol in hotplug events where Windows hasn't created the child device nodes yet (https://github.com/kevinmehall/nusb/issues/149).