### PR TITLE
Future-proof v0.2 DeviceInfo and BusInfo for future Android and WebUSB backends

### DIFF
--- a/src/enumeration.rs
+++ b/src/enumeration.rs
@@ -65,8 +65,6 @@ pub struct DeviceInfo {
     pub(crate) subclass: u8,
     pub(crate) protocol: u8,
 
-    pub(crate) max_packet_size_0: u8,
-
     pub(crate) speed: Option<Speed>,
 
     pub(crate) manufacturer_string: Option<String>,
@@ -228,12 +226,6 @@ impl DeviceInfo {
         self.protocol
     }
 
-    /// Maximum packet size for endpoint zero.
-    #[doc(alias = "bMaxPacketSize0")]
-    pub fn max_packet_size_0(&self) -> u8 {
-        self.max_packet_size_0
-    }
-
     /// Connection speed
     pub fn speed(&self) -> Option<Speed> {
         self.speed
@@ -307,7 +299,6 @@ impl std::fmt::Debug for DeviceInfo {
             .field("class", &format_args!("0x{:02X}", self.class))
             .field("subclass", &format_args!("0x{:02X}", self.subclass))
             .field("protocol", &format_args!("0x{:02X}", self.protocol))
-            .field("max_packet_size_0", &self.max_packet_size_0)
             .field("speed", &self.speed)
             .field("manufacturer_string", &self.manufacturer_string)
             .field("product_string", &self.product_string)

--- a/src/enumeration.rs
+++ b/src/enumeration.rs
@@ -1,7 +1,7 @@
 #[cfg(target_os = "windows")]
 use std::ffi::{OsStr, OsString};
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux"))]
 use crate::platform::SysfsPath;
 
 use crate::{Device, Error, MaybeFuture};
@@ -22,7 +22,7 @@ pub struct DeviceId(pub(crate) crate::platform::DeviceId);
 ///     * macOS: `registry_id`, `location_id`
 #[derive(Clone)]
 pub struct DeviceInfo {
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(target_os = "linux")]
     pub(crate) path: SysfsPath,
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -52,12 +52,24 @@ pub struct DeviceInfo {
     #[cfg(target_os = "macos")]
     pub(crate) location_id: u32,
 
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     pub(crate) bus_id: String,
+
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "windows",
+        target_os = "android"
+    ))]
     pub(crate) device_address: u8,
+
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     pub(crate) port_chain: Vec<u8>,
 
     pub(crate) vendor_id: u16,
     pub(crate) product_id: u16,
+
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     pub(crate) device_version: u16,
 
     pub(crate) usb_version: u16,
@@ -97,14 +109,6 @@ impl DeviceInfo {
     }
 
     /// *(Linux-only)* Sysfs path for the device.
-    #[doc(hidden)]
-    #[deprecated = "use `sysfs_path()` instead"]
-    #[cfg(target_os = "linux")]
-    pub fn path(&self) -> &SysfsPath {
-        &self.path
-    }
-
-    /// *(Linux-only)* Sysfs path for the device.
     #[cfg(target_os = "linux")]
     pub fn sysfs_path(&self) -> &std::path::Path {
         &self.path.0
@@ -113,7 +117,7 @@ impl DeviceInfo {
     /// *(Linux-only)* Bus number.
     ///
     /// On Linux, the `bus_id` is an integer and this provides the value as `u8`.
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(any(target_os = "linux"))]
     pub fn busnum(&self) -> u8 {
         self.busnum
     }
@@ -149,6 +153,7 @@ impl DeviceInfo {
     ///
     /// Since USB SuperSpeed is a separate topology from USB 2.0 speeds, a
     /// physical port may be identified differently depending on speed.
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     pub fn port_chain(&self) -> &[u8] {
         &self.port_chain
     }
@@ -172,11 +177,13 @@ impl DeviceInfo {
     }
 
     /// Identifier for the bus / host controller where the device is connected.
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     pub fn bus_id(&self) -> &str {
         &self.bus_id
     }
 
     /// Number identifying the device within the bus.
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     pub fn device_address(&self) -> u8 {
         self.device_address
     }
@@ -195,6 +202,7 @@ impl DeviceInfo {
 
     /// The device version, normally encoded as BCD, from the `bcdDevice` device descriptor field.
     #[doc(alias = "bcdDevice")]
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     pub fn device_version(&self) -> u16 {
         self.device_version
     }
@@ -227,6 +235,7 @@ impl DeviceInfo {
     }
 
     /// Connection speed
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     pub fn speed(&self) -> Option<Speed> {
         self.speed
     }
@@ -286,16 +295,21 @@ impl std::fmt::Debug for DeviceInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut s = f.debug_struct("DeviceInfo");
 
+        #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
         s.field("bus_id", &self.bus_id)
             .field("device_address", &self.device_address)
-            .field("port_chain", &format_args!("{:?}", self.port_chain))
-            .field("vendor_id", &format_args!("0x{:04X}", self.vendor_id))
-            .field("product_id", &format_args!("0x{:04X}", self.product_id))
-            .field(
-                "device_version",
-                &format_args!("0x{:04X}", self.device_version),
-            )
-            .field("usb_version", &format_args!("0x{:04X}", self.usb_version))
+            .field("port_chain", &format_args!("{:?}", self.port_chain));
+
+        s.field("vendor_id", &format_args!("0x{:04X}", self.vendor_id))
+            .field("product_id", &format_args!("0x{:04X}", self.product_id));
+
+        #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+        s.field(
+            "device_version",
+            &format_args!("0x{:04X}", self.device_version),
+        );
+
+        s.field("usb_version", &format_args!("0x{:04X}", self.usb_version))
             .field("class", &format_args!("0x{:02X}", self.class))
             .field("subclass", &format_args!("0x{:02X}", self.subclass))
             .field("protocol", &format_args!("0x{:02X}", self.protocol))
@@ -307,10 +321,6 @@ impl std::fmt::Debug for DeviceInfo {
         #[cfg(target_os = "linux")]
         {
             s.field("sysfs_path", &self.path);
-        }
-        #[cfg(any(target_os = "linux", target_os = "android"))]
-        {
-            s.field("busnum", &self.busnum);
         }
 
         #[cfg(target_os = "windows")]
@@ -466,15 +476,16 @@ impl UsbControllerType {
 /// * Linux: `path`, `parent_path`, `busnum`, `root_hub`
 /// * Windows: `instance_id`, `parent_instance_id`, `location_paths`, `devinst`, `root_hub_description`
 /// * macOS: `registry_id`, `location_id`, `name`, `provider_class_name`, `class_name`
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub struct BusInfo {
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(any(target_os = "linux"))]
     pub(crate) path: SysfsPath,
 
     /// The phony root hub device
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(any(target_os = "linux"))]
     pub(crate) root_hub: DeviceInfo,
 
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(any(target_os = "linux"))]
     pub(crate) busnum: u8,
 
     #[cfg(target_os = "windows")]
@@ -516,9 +527,10 @@ pub struct BusInfo {
     pub(crate) controller_type: Option<UsbControllerType>,
 }
 
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 impl BusInfo {
     /// *(Linux-only)* Sysfs path for the bus.
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(any(target_os = "linux"))]
     pub fn sysfs_path(&self) -> &std::path::Path {
         &self.path.0
     }
@@ -526,13 +538,13 @@ impl BusInfo {
     /// *(Linux-only)* Bus number.
     ///
     /// On Linux, the `bus_id` is an integer and this provides the value as `u8`.
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(any(target_os = "linux"))]
     pub fn busnum(&self) -> u8 {
         self.busnum
     }
 
     /// *(Linux-only)* The root hub [`DeviceInfo`] representing the bus.
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(any(target_os = "linux"))]
     pub fn root_hub(&self) -> &DeviceInfo {
         &self.root_hub
     }
@@ -622,7 +634,7 @@ impl BusInfo {
     /// * macOS: The [IONameMatched](https://developer.apple.com/documentation/bundleresources/information_property_list/ionamematch) key of the IOService entry.
     /// * Windows: Description field of the root hub device. How the bus will appear in Device Manager.
     pub fn system_name(&self) -> Option<&str> {
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux"))]
         {
             self.root_hub.product_string()
         }
@@ -639,11 +651,12 @@ impl BusInfo {
     }
 }
 
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 impl std::fmt::Debug for BusInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut s = f.debug_struct("BusInfo");
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux"))]
         {
             s.field("sysfs_path", &self.path);
             s.field("busnum", &self.busnum);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,13 +139,16 @@ mod platform;
 
 pub mod descriptors;
 mod enumeration;
-pub use enumeration::{BusInfo, DeviceId, DeviceInfo, InterfaceInfo, Speed, UsbControllerType};
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+pub use enumeration::BusInfo;
+pub use enumeration::{DeviceId, DeviceInfo, InterfaceInfo, Speed, UsbControllerType};
 
 mod device;
 pub use device::{Device, Endpoint, Interface};
 
 pub mod transfer;
 
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub mod hotplug;
 
 mod maybe_future;
@@ -168,6 +171,7 @@ pub use error::{ActiveConfigurationError, Error, ErrorKind, GetDescriptorError};
 ///     .find(|dev| dev.vendor_id() == 0xAAAA && dev.product_id() == 0xBBBB)
 ///     .expect("device not connected");
 /// ```
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub fn list_devices() -> impl MaybeFuture<Output = Result<impl Iterator<Item = DeviceInfo>, Error>>
 {
     platform::list_devices()
@@ -191,10 +195,7 @@ pub fn list_devices() -> impl MaybeFuture<Output = Result<impl Iterator<Item = D
 ///     })
 ///     .collect();
 /// ```
-///
-/// ### Platform-specific notes
-/// * On Linux, the abstraction of the "bus" is a phony device known as the root hub. This device is available at bus.root_hub()
-/// * On Android, this will only work on rooted devices due to sysfs path usage
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub fn list_buses() -> impl MaybeFuture<Output = Result<impl Iterator<Item = BusInfo>, Error>> {
     platform::list_buses()
 }
@@ -234,6 +235,7 @@ pub fn list_buses() -> impl MaybeFuture<Output = Result<impl Iterator<Item = Bus
 ///     when the `Connected` event is emitted. If you are immediately opening the device
 ///     and claiming an interface when receiving a `Connected` event,
 ///     you should retry after a short delay if opening or claiming fails.
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub fn watch_devices() -> Result<hotplug::HotplugWatch, Error> {
     Ok(hotplug::HotplugWatch(platform::HotplugWatch::new()?))
 }

--- a/src/platform/linux_usbfs/enumeration.rs
+++ b/src/platform/linux_usbfs/enumeration.rs
@@ -225,7 +225,6 @@ pub fn probe_device(path: SysfsPath) -> Result<DeviceInfo, SysfsError> {
         class: path.read_attr_hex("bDeviceClass")?,
         subclass: path.read_attr_hex("bDeviceSubClass")?,
         protocol: path.read_attr_hex("bDeviceProtocol")?,
-        max_packet_size_0: path.read_attr("bMaxPacketSize0")?,
         speed: path
             .read_attr::<String>("speed")
             .ok()

--- a/src/platform/linux_usbfs/mod.rs
+++ b/src/platform/linux_usbfs/mod.rs
@@ -6,17 +6,24 @@ use rustix::io::Errno;
 pub(crate) use transfer::TransferData;
 mod usbfs;
 
+#[cfg(not(target_os = "android"))]
 mod enumeration;
-mod events;
+
+#[cfg(not(target_os = "android"))]
 pub use enumeration::{list_buses, list_devices, SysfsPath};
+
+#[cfg(not(target_os = "android"))]
+mod hotplug;
+
+#[cfg(not(target_os = "android"))]
+pub(crate) use hotplug::LinuxHotplugWatch as HotplugWatch;
+
+mod events;
 
 mod device;
 pub(crate) use device::LinuxDevice as Device;
 pub(crate) use device::LinuxEndpoint as Endpoint;
 pub(crate) use device::LinuxInterface as Interface;
-
-mod hotplug;
-pub(crate) use hotplug::LinuxHotplugWatch as HotplugWatch;
 
 use crate::transfer::TransferError;
 use crate::ErrorKind;

--- a/src/platform/macos_iokit/enumeration.rs
+++ b/src/platform/macos_iokit/enumeration.rs
@@ -134,7 +134,6 @@ pub(crate) fn probe_device(device: IoService) -> Option<DeviceInfo> {
         class: get_integer_property(&device, "bDeviceClass")? as u8,
         subclass: get_integer_property(&device, "bDeviceSubClass")? as u8,
         protocol: get_integer_property(&device, "bDeviceProtocol")? as u8,
-        max_packet_size_0: get_integer_property(&device, "bMaxPacketSize0")? as u8,
         speed: get_integer_property(&device, "Device Speed").and_then(map_speed),
         manufacturer_string: get_string_property(&device, "kUSBVendorString")
             .or_else(|| get_string_property(&device, "USB Vendor Name")),

--- a/src/platform/windows_winusb/enumeration.rs
+++ b/src/platform/windows_winusb/enumeration.rs
@@ -138,7 +138,6 @@ pub fn probe_device(devinst: DevInst) -> Option<DeviceInfo> {
         class: info.device_desc.bDeviceClass,
         subclass: info.device_desc.bDeviceSubClass,
         protocol: info.device_desc.bDeviceProtocol,
-        max_packet_size_0: info.device_desc.bMaxPacketSize0,
         speed: info.speed,
         manufacturer_string: None,
         product_string,


### PR DESCRIPTION
Some fields are not available on those platforms, so this preemptively `cfg`s them out or removes them.

`list_devices` and `list_buses` may have worked on rooted Android, but this disables them for now so that JNI-based enumeration can be added without a breaking change. `Device::from_fd` currently supported for non-rooted Android remains available.