### PR TITLE
Fix #168 - Windows: Support timeout on Interface::control_in and control_out

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -426,8 +426,6 @@ impl Interface {
     ///   byte of `index` must match the interface number, or
     ///   `TransferError::InvalidArgument` will be returned. This is a WinUSB
     ///   limitation.
-    /// * On Windows, the timeout is currently fixed to 5 seconds and the
-    ///   timeout argument is ignored.
     pub fn control_in(
         &self,
         data: ControlIn,
@@ -467,8 +465,6 @@ impl Interface {
     ///   byte of `index` must match the interface number, or
     ///   `TransferError::InvalidArgument` will be returned. This is a WinUSB
     ///   limitation.
-    /// * On Windows, the timeout is currently fixed to 5 seconds and the
-    ///   timeout argument is ignored.
     pub fn control_out(
         &self,
         data: ControlOut,

--- a/src/platform/windows_winusb/device.rs
+++ b/src/platform/windows_winusb/device.rs
@@ -126,7 +126,7 @@ impl WindowsDevice {
 
     pub(crate) fn configuration_descriptors(
         &self,
-    ) -> impl Iterator<Item = ConfigurationDescriptor> {
+    ) -> impl Iterator<Item = ConfigurationDescriptor<'_>> {
         self.config_descriptors
             .iter()
             .map(|d| ConfigurationDescriptor::new_unchecked(&d[..]))
@@ -430,6 +430,21 @@ impl WindowsInterface {
         data: ControlIn,
         timeout: Duration,
     ) -> impl MaybeFuture<Output = Result<Vec<u8>, TransferError>> {
+        unsafe {
+            let timeout_ms = timeout.as_millis() as u32;
+            let r = WinUsb_SetPipePolicy(
+                self.winusb_handle,
+                0x00,
+                Usb::PIPE_TRANSFER_TIMEOUT,
+                size_of_val(&timeout_ms) as u32,
+                &timeout_ms as *const _ as *const c_void,
+            );
+            if r != TRUE {
+                let err = GetLastError();
+                warn!("Failed to set timeout {timeout_ms} ms on control endpoint: error {err:x}",);
+            }
+        }
+
         let mut t = TransferData::new(0x80);
         t.set_buffer(Buffer::new(data.length as usize));
 
@@ -455,6 +470,21 @@ impl WindowsInterface {
         data: ControlOut,
         timeout: Duration,
     ) -> impl MaybeFuture<Output = Result<(), TransferError>> {
+        unsafe {
+            let timeout_ms = timeout.as_millis() as u32;
+            let r = WinUsb_SetPipePolicy(
+                self.winusb_handle,
+                0x00,
+                Usb::PIPE_TRANSFER_TIMEOUT,
+                size_of_val(&timeout_ms) as u32,
+                &timeout_ms as *const _ as *const c_void,
+            );
+            if r != TRUE {
+                let err = GetLastError();
+                warn!("Failed to set timeout {timeout_ms} ms on control endpoint: error {err:x}",);
+            }
+        }
+
         let mut t = TransferData::new(0x00);
         t.set_buffer(Buffer::from(data.data.to_vec()));
 

--- a/src/platform/windows_winusb/util.rs
+++ b/src/platform/windows_winusb/util.rs
@@ -152,7 +152,7 @@ impl Display for WCStr {
 pub struct NulSepList(pub Vec<u16>);
 
 impl NulSepList {
-    pub fn iter(&self) -> NulSepListIter {
+    pub fn iter(&self) -> NulSepListIter<'_> {
         NulSepListIter(&self.0)
     }
 }


### PR DESCRIPTION
Per #168.

As well as potentially setting the timeout with a new (Windows only) method on Device, it is also arguable that control_in and control_out should reset the timeout to 5000ms after the transfer.