### PR TITLE
fix: use overlapped on windows get_descriptor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ rustix = { version = "1.0.1", features = ["fs", "event", "net", "time", "mm"] }
 linux-raw-sys = { version = ">= 0.11, <= 0.12", features = ["ioctl"] }
 
 [target.'cfg(target_os="windows")'.dependencies]
-windows-sys = { version = ">= 0.60, <= 0.61", features = ["Win32_Devices_Usb", "Win32_Devices_DeviceAndDriverInstallation", "Win32_Foundation", "Win32_Devices_Properties", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System_IO", "Win32_System_Registry", "Win32_System_Com"] }
+windows-sys = { version = ">= 0.60, <= 0.61", features = ["Win32_Devices_Usb", "Win32_Devices_DeviceAndDriverInstallation", "Win32_Foundation", "Win32_Devices_Properties", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System_IO", "Win32_System_Registry", "Win32_System_Com", "Win32_System_Threading"] }
+scopeguard = "1.2.0"
 
 [target.'cfg(target_os="macos")'.dependencies]
 core-foundation = "0.10.1"

--- a/src/device.rs
+++ b/src/device.rs
@@ -194,7 +194,7 @@ impl Device {
             let _ = timeout;
             self.backend
                 .clone()
-                .get_descriptor(desc_type, desc_index, language_id)
+                .get_descriptor(desc_type, desc_index, language_id, timeout)
                 .map(|r| r.map_err(GetDescriptorError::Transfer))
         }
 

--- a/src/platform/windows_winusb/enumeration.rs
+++ b/src/platform/windows_winusb/enumeration.rs
@@ -16,6 +16,7 @@ use crate::{
         DESCRIPTOR_TYPE_CONFIGURATION, DESCRIPTOR_TYPE_STRING,
     },
     maybe_future::{blocking::Blocking, MaybeFuture},
+    platform::windows_winusb::util::DEFAULT_TRANSFER_TIMEOUT,
     BusInfo, DeviceInfo, Error, ErrorKind, InterfaceInfo, UsbControllerType,
 };
 
@@ -80,6 +81,7 @@ pub fn probe_device(devinst: DevInst) -> Option<DeviceInfo> {
                 DESCRIPTOR_TYPE_STRING,
                 info.device_desc.iSerialNumber,
                 US_ENGLISH,
+                DEFAULT_TRANSFER_TIMEOUT,
             )
             .ok()
             .and_then(|data| decode_string_descriptor(&data).ok())
@@ -196,6 +198,7 @@ fn list_interfaces_from_desc(hub_port: &HubPort, active_config: u8) -> Option<Ve
             DESCRIPTOR_TYPE_CONFIGURATION,
             active_config.saturating_sub(1),
             0,
+            DEFAULT_TRANSFER_TIMEOUT,
         )
         .ok()?;
     let desc = ConfigurationDescriptor::new(&buf[..])?;

--- a/src/platform/windows_winusb/util.rs
+++ b/src/platform/windows_winusb/util.rs
@@ -17,6 +17,8 @@ use windows_sys::Win32::{
     },
 };
 
+pub const DEFAULT_TRANSFER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 /// Wrapper around `CreateFile`
 pub fn create_file(path: &WCStr) -> Result<OwnedHandle, WIN32_ERROR> {
     unsafe {


### PR DESCRIPTION
Consider draft, Non polished. Attempt to add support on windows get_descriptor timeout, also I saw the other PR's (though different approach) related to this so decided not spend too much time on this. I do admit there might be some caveat with using overlapped.