### PR TITLE
Update `windows-sys` to `>= 0.60, <= 0.61` and `linux-raw-sys` to 0.12.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { version = "1", features = ["rt", "macros", "io-util", "rt-multi-thread
 
 [target.'cfg(any(target_os="linux", target_os="android"))'.dependencies]
 rustix = { version = "1.0.1", features = ["fs", "event", "net", "time", "mm"] }
-linux-raw-sys = { version = "0.12.1", features = ["ioctl"] }
+linux-raw-sys = { version = ">= 0.11, <= 0.12", features = ["ioctl"] }
 
 [target.'cfg(target_os="windows")'.dependencies]
 windows-sys = { version = ">= 0.60, <= 0.61", features = ["Win32_Devices_Usb", "Win32_Devices_DeviceAndDriverInstallation", "Win32_Foundation", "Win32_Devices_Properties", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System_IO", "Win32_System_Registry", "Win32_System_Com"] }


### PR DESCRIPTION
`windows-sys` 0.61.x is very important for me, because it consistently uses `raw-dylib` for importing APIs from Windows DLLs. This makes a huge difference when using non-MSVC toolchains to build Windows binaries, e.g. `x86_64-pc-windows-gnullvm`.

I also took the opportunity to update `linux-raw-sys` to the latest release.

`cargo test` worked for me on both Windows and Linux.

CC @kevinmehall 