### PR TITLE
default to configuration 0 if the `bConfigurationValue` file is empty

### DIFF
--- a/src/platform/linux_usbfs/device.rs
+++ b/src/platform/linux_usbfs/device.rs
@@ -145,7 +145,8 @@ impl LinuxDevice {
         let active_config: u8 = if let Some(sysfs) = sysfs.as_ref() {
             match sysfs.read_attr("bConfigurationValue") {
                 Ok(v) => v,
-                // the attr is probably empty, so default to 0
+                // Linux returns an empty string when the device is unconfigured.
+                // We'll assume all parse errors are the empty string.
                 Err(SysfsError(_, SysfsErrorKind::Parse(_))) => 0,
 
                 Err(e) => {

--- a/src/platform/linux_usbfs/enumeration.rs
+++ b/src/platform/linux_usbfs/enumeration.rs
@@ -15,10 +15,10 @@ use crate::{BusInfo, DeviceInfo, Error, Speed, UsbControllerType};
 pub struct SysfsPath(pub(crate) PathBuf);
 
 #[derive(Debug)]
-pub struct SysfsError(pub PathBuf, pub SysfsErrorKind);
+pub struct SysfsError(pub(crate) PathBuf, pub(crate) SysfsErrorKind);
 
 #[derive(Debug)]
-pub enum SysfsErrorKind {
+pub(crate) enum SysfsErrorKind {
     Io(io::Error),
     Parse(String),
 }


### PR DESCRIPTION
if that file is empty, you'll get locked out, because you can't open the device so you can set a configuration