### PR TITLE
windows: generalize composite parent driver check

### DIFF
--- a/src/platform/windows_winusb/device.rs
+++ b/src/platform/windows_winusb/device.rs
@@ -180,6 +180,7 @@ impl WindowsDevice {
             let mut handles = self.handles.lock().unwrap();
 
             if driver.eq_ignore_ascii_case("winusb") {
+                // Whole device bound to WinUSB (non-composite).
                 match handles.entry(0) {
                     Entry::Occupied(mut e) => e.get_mut().claim_interface(&self, interface_number),
                     Entry::Vacant(e) => {
@@ -190,7 +191,12 @@ impl WindowsDevice {
                         Ok(intf)
                     }
                 }
-            } else if driver.eq_ignore_ascii_case("usbccgp") {
+            } else {
+                // Composite device — walk child device nodes to find the interface.
+                // Works for usbccgp (Microsoft), dg_ssudbus (Samsung), and any
+                // OEM composite parent driver. The child-level WinUSB check in
+                // get_usbccgp_winusb_device_path ensures we only open interfaces
+                // whose driver is WinUSB.
                 let (first_interface, child_dev) =
                     find_usbccgp_child(self.devinst, interface_number)
                         .ok_or_else(|| Error::new(ErrorKind::NotFound, "Interface not found"))?;
@@ -209,12 +215,6 @@ impl WindowsDevice {
                         Ok(intf)
                     }
                 }
-            } else {
-                debug!("Device driver is {driver:?}, not WinUSB or USBCCGP");
-                Err(Error::new(
-                    ErrorKind::Unsupported,
-                    "incompatible driver is installed for this device",
-                ))
             }
         })
     }

--- a/src/platform/windows_winusb/enumeration.rs
+++ b/src/platform/windows_winusb/enumeration.rs
@@ -92,8 +92,9 @@ pub fn probe_device(devinst: DevInst) -> Option<DeviceInfo> {
     let mut interfaces =
         list_interfaces_from_desc(&hub_port, info.active_config).unwrap_or_default();
 
-    if driver.eq_ignore_ascii_case("usbccgp") {
+    if !driver.eq_ignore_ascii_case("winusb") {
         // Populate interface descriptor strings when available from child device nodes.
+        // Works for usbccgp, dg_ssudbus (Samsung), and any OEM composite parent.
         devinst
             .children()
             .flat_map(|intf| {


### PR DESCRIPTION
## Problem

  On Windows, `claim_interface` only recognizes `usbccgp` and `winusb` as parent device drivers. Any other composite
  parent driver fails with "incompatible driver is installed for this device."

  Samsung Android devices use `dg_ssudbus` (Samsung's proprietary composite bus driver) instead of Microsoft's
  `usbccgp`. Samsung's driver creates the same child device node structure as `usbccgp`, and the ADB child interface is
  bound to WinUSB — but nusb rejects the device before ever checking the child.

  This affects Samsung Galaxy S20, S21, S22, S23, S24, Note series, A series, and any Samsung device using the Samsung
  USB Driver package. It may also affect other OEMs with custom composite parent drivers (Huawei, Oppo, etc.).

  ## Root Cause

  In `device.rs`, the `claim_interface` method has a three-way branch:
  - `winusb` → open device directly ✓
  - `usbccgp` → walk child device nodes, find WinUSB child ✓
  - **anything else → error** ← Samsung fails here

  The child-walking logic in the `usbccgp` branch works perfectly for `dg_ssudbus` devices — the child device tree
  structure is identical. The only barrier was the parent driver name check.

  Similarly, `probe_device` in `enumeration.rs` only populates interface descriptor strings from child device nodes when
   the parent is `usbccgp`.

  ## Fix

  **`device.rs`:** Restructure from three-way to two-way branch:
  - `winusb` → open directly (unchanged)
  - **everything else** → try composite child path

  The existing child-level WinUSB check in `get_usbccgp_winusb_device_path` is preserved — only interfaces whose driver
  is WinUSB can be opened. If no WinUSB child is found, the function still returns an appropriate error.

  **`enumeration.rs`:** Change `probe_device` interface string population from `if usbccgp` to `if !winusb` — populate
  strings from child nodes for any composite parent.

  ## Testing

  Tested on 4 real devices:

  | Device | Parent Driver | Result |
  |--------|--------------|--------|
  | Samsung Galaxy S20 (SM-G9810) | `dg_ssudbus` | **Now works** — 1119 ADB properties queried via USB |
  | Xiaomi 11 Lite 5G NE | `usbccgp` | Works (no regression) |
  | Xiaomi Redmi K20 Pro | `usbccgp` | Works (no regression) |
  | Motorola moto g 2025 | `usbccgp` | Works (no regression) |

  All existing nusb tests pass (24/24).

  ## Context

  Samsung's USB driver package (`ssudbus.inf` + `ssudadb.inf`) installs:
  - `ssudbus.sys` as the composite parent (service: `dg_ssudbus`) — replaces `usbccgp`
  - `WinUSB.sys` as the ADB child interface driver — registers GUID `{F72FE0D4-CBCB-407d-8814-9ED673D0DD6B}`

