### PR TITLE
macos: demote interface close-on-drop failures to debug

### DIFF
--- a/src/platform/macos_iokit/device.rs
+++ b/src/platform/macos_iokit/device.rs
@@ -480,8 +480,11 @@ impl MacInterface {
 
 impl Drop for MacInterface {
     fn drop(&mut self) {
+        // Log at debug, matching the `MacDevice` drop at the top of this file:
+        // close() errors are common during unplug (kIOReturnNoDevice) and, since
+        // Drop can't recover anyway, aren't worth surfacing at error level.
         if let Err(err) = self.interface.close() {
-            error!("Failed to close interface: {err}")
+            debug!("Failed to close interface: {err:x}")
         }
         self.device
             .claimed_interfaces

--- a/src/platform/macos_iokit/device.rs
+++ b/src/platform/macos_iokit/device.rs
@@ -480,9 +480,7 @@ impl MacInterface {
 
 impl Drop for MacInterface {
     fn drop(&mut self) {
-        // Log at debug, matching the `MacDevice` drop at the top of this file:
-        // close() errors are common during unplug (kIOReturnNoDevice) and, since
-        // Drop can't recover anyway, aren't worth surfacing at error level.
+        // Expected to fail with kIOReturnNoDevice when the device is disconnected and can be ignored
         if let Err(err) = self.interface.close() {
             debug!("Failed to close interface: {err:x}")
         }


### PR DESCRIPTION
Hi again!

We chatted a month ago [here](https://github.com/kevinmehall/nusb/discussions/190).

**tl;dr:** I ran into an inconvenience with `nusb` and brought this tiny PR to demote an `error` to `debug`.

### Context

I've been testing [mtp-rs](https://github.com/vdavid/mtp-rs) with my file manager [Cmdr](https://github.com/vdavid/cmdr) and [FUSE tool](https://github.com/vdavid/mtp-mount), which involved many USB plugs/unplugs.

### Problem

I noticed that every time I pull my phone off USB mid-session, I get a

```
ERROR nusb::platform::macos_iokit::device  Failed to close interface: -536870208
```

`-536870208` is `kIOReturnNoDevice` (`0xE00002C0`) from `IOUSBInterfaceClose()`, firing in `MacInterface::drop` because IOKit has already torn the interface down. `Drop` can't do anything about it, and the OS releases resources anyway. It's noise on a routine unplug.

Also, `MacDevice::drop` two blocks up in the same file already logs close failures at `debug!`. `MacInterface::drop` was the outlier.

### Solution

Demote this `error!` to `debug!` too, with a short comment pointing at the `MacDevice` precedent. No behavior change beyond the log level. That's it.

- `cargo build` clean
- `cargo test` clean (13 doctests pass)
- `cargo fmt --check` clean

Happy to restructure if you'd prefer to keep `error!` and match specifically on `kIOReturnNoDevice` (or a small allowlist of expected errors). I went with the simpler path because it matches the precedent in the same file.
I can also remove the long comment if you feel that it's unnecessary 🙁 