### PR TITLE
`control_in` variant that writes into provided buffer

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -1,3 +1,4 @@
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "android"))]
 use crate::{
     descriptors::{
         decode_string_descriptor, validate_string_descriptor, ConfigurationDescriptor,
@@ -318,6 +319,48 @@ impl Device {
         self.backend.clone().control_in(data, timeout)
     }
 
+    /// Submit a single **IN (device-to-host)** transfer on the default **control** endpoint.
+    ///
+    /// This is a variant of [`control_in`](Self::control_in) that writes the output data into a provided buffer.
+    ///
+    /// ### Example
+    ///
+    /// ```no_run
+    /// use std::time::Duration;
+    /// use futures_lite::future::block_on;
+    /// use nusb::transfer::{ ControlIn, ControlType, Recipient };
+    /// # use nusb::MaybeFuture;
+    /// # fn main() -> Result<(), std::io::Error> {
+    /// # let di = nusb::list_devices().wait().unwrap().next().unwrap();
+    /// # let device = di.open().wait().unwrap();
+    ///
+    /// let mut buf = [0; 64];
+    ///
+    /// let num_received = device.control_in_buf(ControlIn {
+    ///     control_type: ControlType::Vendor,
+    ///     recipient: Recipient::Device,
+    ///     request: 0x30,
+    ///     value: 0x0,
+    ///     index: 0x0,
+    ///     length: 64,
+    /// }, Duration::from_millis(100), &mut buf).wait()?;
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// ### Platform-specific details
+    ///
+    /// * Not supported on Windows. You must [claim an interface][`Device::claim_interface`]
+    ///   and use the interface handle to submit transfers.
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "android"))]
+    pub fn control_in_buf<'a>(
+        &self,
+        data: ControlIn,
+        timeout: Duration,
+        buf: &'a mut [u8],
+    ) -> impl MaybeFuture<Output = Result<usize, TransferError>> + 'a {
+        self.backend.clone().control_in_buf(data, timeout, buf)
+    }
+
     /// Submit a single **OUT (host-to-device)** transfer on the default **control** endpoint.
     ///
     /// ### Example
@@ -434,6 +477,52 @@ impl Interface {
         timeout: Duration,
     ) -> impl MaybeFuture<Output = Result<Vec<u8>, TransferError>> {
         self.backend.clone().control_in(data, timeout)
+    }
+
+    /// Submit a single **IN (device-to-host)** transfer on the default **control** endpoint.
+    ///
+    /// This is a variant of [`control_in`](Self::control_in) that writes the output data into a provided buffer.
+    ///
+    /// ### Example
+    ///
+    /// ```no_run
+    /// use std::time::Duration;
+    /// use futures_lite::future::block_on;
+    /// use nusb::transfer::{ ControlIn, ControlType, Recipient };
+    /// # use nusb::MaybeFuture;
+    /// # fn main() -> Result<(), std::io::Error> {
+    /// # let di = nusb::list_devices().wait().unwrap().next().unwrap();
+    /// # let device = di.open().wait().unwrap();
+    /// # let interface = device.claim_interface(0).wait().unwrap();
+    ///
+    /// let mut buf = [0; 64];
+    ///
+    /// let num_received = interface.control_in_buf(ControlIn {
+    ///     control_type: ControlType::Vendor,
+    ///     recipient: Recipient::Device,
+    ///     request: 0x30,
+    ///     value: 0x0,
+    ///     index: 0x0,
+    ///     length: 64,
+    /// }, Duration::from_millis(100), &mut buf).wait()?;
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// ### Platform-specific details
+    /// * On Windows, if the `recipient` is `Interface`, the least significant
+    ///   byte of `index` must match the interface number, or
+    ///   `TransferError::InvalidArgument` will be returned. This is a WinUSB
+    ///   limitation.
+    /// * On Windows, the timeout is currently fixed to 5 seconds and the
+    ///   timeout argument is ignored.
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "android"))]
+    pub fn control_in_buf<'a>(
+        &self,
+        data: ControlIn,
+        timeout: Duration,
+        buf: &'a mut [u8],
+    ) -> impl MaybeFuture<Output = Result<usize, TransferError>> + 'a {
+        self.backend.clone().control_in_buf(data, timeout, buf)
     }
 
     /// Submit a single **OUT (host-to-device)** transfer on the default

--- a/src/platform/linux_usbfs/device.rs
+++ b/src/platform/linux_usbfs/device.rs
@@ -389,6 +389,29 @@ impl LinuxDevice {
         })
     }
 
+    pub fn control_in_buf<'a>(
+        self: Arc<Self>,
+        data: ControlIn,
+        timeout: Duration,
+        buf: &'a mut [u8],
+    ) -> impl MaybeFuture<Output = Result<usize, TransferError>> + 'a {
+        assert!(usize::from(data.length) <= buf.len());
+
+        let t = TransferData::new_control_in(data);
+        TransferFuture::new(t, |t| self.submit_timeout(t, timeout)).map(move |t| {
+            drop(self); // ensure device stays alive
+            t.status()?;
+
+            let in_data = t.control_in_data();
+
+            // can the returned length ever be longer? no, right?
+            let buf = &mut buf[..in_data.len()];
+
+            buf.copy_from_slice(in_data);
+            Ok(in_data.len())
+        })
+    }
+
     pub fn control_out(
         self: Arc<Self>,
         data: ControlOut,
@@ -646,6 +669,15 @@ impl LinuxInterface {
         timeout: Duration,
     ) -> impl MaybeFuture<Output = Result<Vec<u8>, TransferError>> {
         self.device.clone().control_in(data, timeout)
+    }
+
+    pub fn control_in_buf<'a>(
+        &self,
+        data: ControlIn,
+        timeout: Duration,
+        buf: &'a mut [u8],
+    ) -> impl MaybeFuture<Output = Result<usize, TransferError>> + 'a {
+        self.device.clone().control_in_buf(data, timeout, buf)
     }
 
     pub fn control_out(

--- a/src/platform/macos_iokit/device.rs
+++ b/src/platform/macos_iokit/device.rs
@@ -299,6 +299,38 @@ impl MacDevice {
         })
     }
 
+    pub fn control_in_buf<'a>(
+        self: Arc<Self>,
+        data: ControlIn,
+        timeout: Duration,
+        buf: &'a mut [u8],
+    ) -> impl MaybeFuture<Output = Result<usize, TransferError>> + 'a {
+        assert!(usize::from(data.length) <= buf.len());
+
+        let timeout = timeout.as_millis().try_into().expect("timeout too long");
+        let t = unsafe {
+            TransferData::from_raw(buf.as_mut_ptr(), data.length as u32, buf.len() as u32)
+        };
+
+        let req = IOUSBDevRequestTO {
+            bmRequestType: data.request_type(),
+            bRequest: data.request,
+            wValue: data.value,
+            wIndex: data.index,
+            wLength: data.length,
+            pData: t.buf as *mut c_void,
+            wLenDone: 0,
+            completionTimeout: timeout,
+            noDataTimeout: timeout,
+        };
+
+        TransferFuture::new(t, |t| self.submit_control(Direction::In, t, req)).map(move |t| {
+            drop(self); // ensure device stays alive
+            t.status()?;
+            Ok(t.actual_len as usize)
+        })
+    }
+
     pub fn control_out(
         self: Arc<Self>,
         data: ControlOut,
@@ -432,6 +464,15 @@ impl MacInterface {
         timeout: Duration,
     ) -> impl MaybeFuture<Output = Result<Vec<u8>, TransferError>> {
         self.device.clone().control_in(data, timeout)
+    }
+
+    pub fn control_in_buf<'a>(
+        &self,
+        data: ControlIn,
+        timeout: Duration,
+        buf: &'a mut [u8],
+    ) -> impl MaybeFuture<Output = Result<usize, TransferError>> + 'a {
+        self.device.clone().control_in_buf(data, timeout, buf)
     }
 
     pub fn control_out(

--- a/src/platform/windows_winusb/device.rs
+++ b/src/platform/windows_winusb/device.rs
@@ -450,6 +450,37 @@ impl WindowsInterface {
         })
     }
 
+    pub fn control_in_buf<'a>(
+        self: Arc<Self>,
+        data: ControlIn,
+        timeout: Duration,
+        buf: &'a mut [u8],
+    ) -> impl MaybeFuture<Output = Result<usize, TransferError>> + 'a {
+        assert!(usize::from(data.length) <= buf.len());
+
+        let mut t = TransferData::new(0x80);
+        t.set_buffer(unsafe {
+            // SAFETY: `buf` is exclusively borrowed for the duration when the created buffer has a `*mut u8` to it.
+            Buffer::from_slice(buf.as_mut_ptr())
+        });
+
+        let pkt = WINUSB_SETUP_PACKET {
+            RequestType: data.request_type(),
+            Request: data.request,
+            Value: data.value,
+            Index: data.index,
+            Length: data.length,
+        };
+
+        let intf = self.clone();
+
+        TransferFuture::new(t, |t| self.submit_control(t, pkt)).map(move |mut t| {
+            let c = t.take_completion(&intf);
+            c.status?;
+            Ok(c.buffer.len())
+        })
+    }
+
     pub fn control_out(
         self: &Arc<Self>,
         data: ControlOut,

--- a/src/transfer/buffer.rs
+++ b/src/transfer/buffer.rs
@@ -9,6 +9,8 @@ pub(crate) enum Allocator {
     Default,
     #[cfg(any(target_os = "linux", target_os = "android"))]
     Mmap,
+    #[cfg(target_os = "windows")]
+    None,
 }
 
 /// Buffer for bulk and interrupt transfers.
@@ -94,6 +96,18 @@ impl Buffer {
             capacity: len_u32,
             allocator: Allocator::Mmap,
         })
+    }
+
+    #[cfg(target_os = "windows")]
+    pub(crate) unsafe fn from_raw(ptr: *mut u8, requested_len: usize, capacity: usize) -> Self {
+        let len_u32 = requested_len.try_into().expect("length overflow");
+        Buffer {
+            ptr,
+            len: 0,
+            requested_len: len_u32,
+            capacity: capacity.try_into().expect("capacity overflow"),
+            allocator: Allocator::None,
+        }
     }
 
     /// Get the number of initialized bytes in the buffer.
@@ -290,6 +304,8 @@ impl Drop for Buffer {
             Allocator::Mmap => unsafe {
                 rustix::mm::munmap(self.ptr as *mut _, self.capacity as usize).unwrap();
             },
+            #[cfg(target_os = "windows")]
+            Allocator::None => {}
         }
     }
 }


### PR DESCRIPTION
I disliked the fact that `control_in` allocates a `Vec<u8>`, so I added a `control_in_buf` variant that uses a user-provided buffer.

Is this something you want?

Only tested on Linux so far. Cross-compilation doesn't work. Looks like `cfg(target_os = "windows")` isn't recognized. Any tips?