### PR TITLE
Fix deadlock in wait_next_complete if completion callbacks occur out of order

### DIFF
--- a/src/transfer/internal.rs
+++ b/src/transfer/internal.rs
@@ -58,8 +58,8 @@ impl Notify {
     }
 
     pub fn wait<T>(&self, mut check: impl FnMut() -> Option<T>) -> T {
-        *self.state.lock().unwrap() = NotifyState::Thread(thread::current());
         loop {
+            *self.state.lock().unwrap() = NotifyState::Thread(thread::current());
             if let Some(result) = check() {
                 return result;
             }
@@ -72,9 +72,9 @@ impl Notify {
         timeout: Duration,
         mut check: impl FnMut() -> Option<T>,
     ) -> Option<T> {
-        *self.state.lock().unwrap() = NotifyState::Thread(thread::current());
         let start = Instant::now();
         loop {
+            *self.state.lock().unwrap() = NotifyState::Thread(thread::current());
             if let Some(result) = check() {
                 return Some(result);
             }


### PR DESCRIPTION
Since https://github.com/kevinmehall/nusb/pull/163, the `Notify` state is cleared when it is woken. If it is woken by a transfer other than the next one in the queue, the check will return None, and it will go around the loop without resetting the `Notify` state and will not be woken again.

This was observed on Illumos (https://github.com/kevinmehall/nusb/pull/198), but may also affect Windows after https://github.com/kevinmehall/nusb/pull/171. Prior to that, all platforms handled events on a single thread, with a separate Notify per endpoint, and seemed to always complete in order, so I am not sure this can actually occur on a released version of nusb.