### PR TITLE
linux+macos: Name the event thread

### DIFF
--- a/src/platform/linux_usbfs/events.rs
+++ b/src/platform/linux_usbfs/events.rs
@@ -67,7 +67,10 @@ pub(super) fn register_fd(fd: BorrowedFd, tag: Tag, flags: EventFlags) -> Result
     })?;
 
     if start_thread {
-        thread::spawn(event_loop);
+        thread::Builder::new()
+            .name("nusb-events".into())
+            .spawn(event_loop)
+            .unwrap();
     }
 
     epoll::add(epoll_fd, fd, tag.as_event_data(), flags)

--- a/src/platform/macos_iokit/events.rs
+++ b/src/platform/macos_iokit/events.rs
@@ -34,14 +34,19 @@ pub(crate) fn add_event_source(source: CFRunLoopSource) -> EventRegistration {
         let (tx, rx) = mpsc::channel();
         let source = SendCFRunLoopSource(source.clone());
         info!("starting event loop thread");
-        thread::spawn(move || {
-            let runloop = CFRunLoop::get_current();
-            let source = source;
-            runloop.add_source(&source.0, unsafe { kCFRunLoopCommonModes });
-            tx.send(runloop).unwrap();
-            CFRunLoop::run_current();
-            info!("event loop thread exited");
-        });
+
+        thread::Builder::new()
+            .name("nusb-events".into())
+            .spawn(move || {
+                let runloop = CFRunLoop::get_current();
+                let source = source;
+                runloop.add_source(&source.0, unsafe { kCFRunLoopCommonModes });
+                tx.send(runloop).unwrap();
+                CFRunLoop::run_current();
+                info!("event loop thread exited");
+            })
+            .unwrap();
+
         event_loop.runloop = Some(rx.recv().expect("failed to start run loop thread"));
         event_loop.count = 1;
     }


### PR DESCRIPTION
The name is visible in various debug tools as well as panic messages.