### PR TITLE
Consider EACCESS when opening a device on Linux

### DIFF
--- a/src/platform/linux_usbfs/device.rs
+++ b/src/platform/linux_usbfs/device.rs
@@ -97,7 +97,7 @@ impl LinuxDevice {
                         Errno::NOENT => {
                             Error::new_os(ErrorKind::Disconnected, "device not found", e)
                         }
-                        Errno::PERM => {
+                        Errno::PERM | Errno::ACCESS => {
                             Error::new_os(ErrorKind::PermissionDenied, "permission denied", e)
                         }
                         e => Error::new_os(ErrorKind::Other, "failed to open device", e),


### PR DESCRIPTION
At least on my system running kernel 7.0, a failure to access a device file under /dev/bus/usb/ gives EACCESS rather than EPERM.
Taking EACCESS into account in the match statement in from_device_info improves the error message in this case.