### PR TITLE
linux: Fix event loop spinning when a HotplugWatch is created but never polled and its receive buffer fills

### DIFF
--- a/src/platform/linux_usbfs/events.rs
+++ b/src/platform/linux_usbfs/events.rs
@@ -119,7 +119,7 @@ pub(crate) struct Async<T: AsFd> {
 impl<T: AsFd> Async<T> {
     pub fn new(inner: T) -> Result<Self, Error> {
         let id = WAKERS.lock().unwrap().insert(None);
-        register_fd(inner.as_fd(), Tag::Waker(id), EventFlags::empty())?;
+        register_fd(inner.as_fd(), Tag::Waker(id), EventFlags::ONESHOT)?;
         Ok(Async { inner, id })
     }
 


### PR DESCRIPTION
The udev netlink fd was initially registered in epoll with an empty flag set, and the kernel implicitly enables error events. Any error event at this point will continually wake the event loop. When the HotplugWatch is polled, the epoll watch is re-armed with the ONESHOT flag, which prevents this, so it was only a problem when calling `watch_devices` and then holding but never polling the `HotplugWatch`.