### PR TITLE
"feat": feature flag to allow blocking work in Futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,10 @@ smol = ["dep:blocking", "dep:futures-io"]
 # Use `tokio`'s IO threadpool for making blocking IO async
 tokio = ["dep:tokio"]
 
+# Run blocking Futures on the async executor that should be run in an async threadpool
+# (not recommended, intended for simple executors like pollster/swait)
+blocking-in-async = []
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
 

--- a/src/maybe_future.rs
+++ b/src/maybe_future.rs
@@ -106,10 +106,19 @@ pub mod blocking {
             Self(tokio::task::spawn_blocking(f))
         }
 
+        #[cfg(feature = "blocking-in-async")]
         #[cfg(not(any(feature = "smol", feature = "tokio")))]
-        fn spawn(_f: impl FnOnce() -> R + Send + 'static) -> Self {
-            panic!("Awaiting blocking syscall without an async runtime: enable the `smol` or `tokio` feature of nusb.");
+        fn spawn(f: impl FnOnce() -> R + Send + 'static) -> Self {
+            Self(Some(f()))
         }
+
+        #[cfg(not(any(feature = "smol", feature = "tokio", feature = "blocking-in-async")))]
+        compile_error!(concat!(
+            "Would await blocking syscall without an async runtime: ",
+            "enable nusb's `smol` or `tokio` feature to run blocking IO on an async threadpool, ",
+            "or `blocking-in-async` to run blocking IO directly on the async executor ",
+            "(not recommended unless you're intentionally minimizing dependencies)."
+        ));
     }
 
     impl<R> Unpin for BlockingTask<R> {}
@@ -133,7 +142,13 @@ pub mod blocking {
             }
         }
 
+        #[cfg(feature = "blocking-in-async")]
         #[cfg(not(any(feature = "smol", feature = "tokio")))]
+        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+            Poll::Ready(self.get_mut().0.take().expect("polled after completion"))
+        }
+
+        #[cfg(not(any(feature = "smol", feature = "tokio", feature = "blocking-in-async")))]
         fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
             unreachable!()
         }


### PR DESCRIPTION
> In theory, MaybeFuture could provide something like then as we used to use for Future in the pre-await era, but it would be pretty cumbersome to use.

I did read this originally, but only after the last two weeks do I actually understand the pain :sweat_smile:

Being `async` runtime or even `async`/sync-agnostic is something I've desired [in the past](https://github.com/nullstalgia/gbasend-rs#repo-contents), today for my current project, and likely will in the future as well.

Even something as "simple" as sleeping for a short period of time is an issue, which I get! Sometimes you _can_ keep it all in userspace, sometimes you're putting a microcontroller core to sleep until an interrupt hits, it's not as trivial to have a universal Sleep future... which is an absolute pain when the protocol documentation I'm dealing with says "wait 1/16th of a second between poll attempts" and _now_ I'm pulling in [DelayNs](https://docs.rs/embedded-hal/1.0.0/embedded_hal/delay/trait.DelayNs.html) from the `embedded-hal` crate on my [PC builds](https://github.com/nullstalgia/gbasend-rs/blob/5b20987ec5b859cb8d8012f175501037c0598880/gbasend-cli/src/serial_spi.rs#L48) so that I can have a shared abstraction between it and my [embedded](https://github.com/nullstalgia/gbasend-rs/blob/5b20987ec5b859cb8d8012f175501037c0598880/gbasend-pico/src/gbasend-picotest.rs#L177) builds and put it as a [supertrait](https://github.com/nullstalgia/gbasend-rs/blob/5b20987ec5b859cb8d8012f175501037c0598880/gbasend-lib/src/traits.rs#L13) to a trait that also has all the SPI bus stuff and-

Anyway, X/Y problem that I've been working on is: I need to reliably poke a USB device with Ctrl and Bulk endpoints, and potentially serve a `cdylib` for Windows and Android. Ideally, I could freely drop in `tokio` or whatever when being directly included as a dependency, but also be able to run the whole thing synchronously when I'm compiling the dylib frontend, to minimize potential points of failure in an already-fragile context.

I started experimenting with combinators for `MaybeFuture`, starting with stuff like `map_ok` and `map_err`. I ended up getting really far with ones based off `futures-rs`'s combinators, resulting in the creations of gems like `EitherMaybeFuture`, eventually _`(Try)FlattenMaybeFuture`_ and sketch-out for a `TryFold/Collect/ForEachMaybeFuture` before realizing that I am just reinventing `async`/`await` with stone knives and bearskins. It took a single `for` loop in my actual application to break my will to continue there. Restructuring a couple functions to use `async`, it flows far more naturally while also being shorter to express... At least I learned a lot about `async`'s internals and how to ~~express stuff with traits/type bounds~~ wrestle the trait solver into submission.

---

> ... [you] can use `block_on` from `pollster` or `futures_lite` ... It does add the overhead of ... running blocking syscalls like `open`, `claim_interface` on a thread pool thread ...

After staring at the recently-posted #212 and my own runtime panics while benchmarking `pollster`, here I am with this two-birds-one-stone "idea"; optionally allow running the `BlockingTask` closures directly, and changing the runtime `.await` panic into a compile-time error asking to choose one of the three possibilities. If any of the actual runtimes are enabled while `blocking-in-async` is enabled, they're preferred in the same order they were originally (`smol` > `tokio` > `blocking-in-async` > `compile_error!`).

I know this probably wouldn't fit well with any isochronous design, and I'm unaware if any of the `.wait()` vs `IntoFuture` implementations are significantly different enough to cause later issues, but it seems to work well enough in my naive tests. I'd love to hear if you've considered this or other ideas before.

---

I'm also considering also sending a PR to `pollster` itself, since their `FutureExt` is only blanket-impl'd for `T: Future`, not `T: IntoFuture` even though the actual `fn` is generic over `T: IntoFuture`. This boils down to invoking `MaybeFuture`s with `x.into_future().block_on()` or `block_on(x)` (unless I choose to just make my *entire* API surface `async` and not have a single `-> impl MaybeFuture` public for _consistency's_ sake).

Part of my intent with this PR and associated ramblings is also just me asking, "am I missing something?" Is there an easier way to be mostly agnostic with your core functionality of poking a known protocol, of which is both simple yet complex enough to be a genuine challenge to maintain a sync *and* `async` variant of? Am I just making things more complicated than they need to be? :P