### PR TITLE
macos: Fix leak of TransferInner on every successful control_in

### DIFF
--- a/src/platform/macos_iokit/device.rs
+++ b/src/platform/macos_iokit/device.rs
@@ -294,8 +294,7 @@ impl MacDevice {
         TransferFuture::new(t, |t| self.submit_control(Direction::In, t, req)).map(move |t| {
             drop(self); // ensure device stays alive
             t.status()?;
-            let t = ManuallyDrop::new(t);
-            Ok(unsafe { Vec::from_raw_parts(t.buf, t.actual_len as usize, t.capacity as usize) })
+            Ok(take_completed_vec(t))
         })
     }
 
@@ -682,5 +681,67 @@ extern "C" fn transfer_callback(refcon: *mut c_void, result: IOReturn, len: *mut
         (*transfer).actual_len = len;
         (*transfer).status = result;
         notify_completion::<TransferData>(transfer)
+    }
+}
+
+/// Extract the completed `control_in` buffer, letting the transfer handle drop
+/// so the boxed `TransferInner` (and its completion `Notify`) is freed.
+///
+/// Wrapping the whole `Idle<TransferData>` in `ManuallyDrop` to steal the
+/// buffer leaks the `TransferInner` allocation (including a pthread mutex in
+/// its `Notify`) on every successful `control_in`. Swap the buffer fields out
+/// instead — the same pattern as `TransferData::take_completion` — and let the
+/// transfer drop normally.
+fn take_completed_vec(mut t: crate::transfer::internal::Idle<TransferData>) -> Vec<u8> {
+    let mut empty = ManuallyDrop::new(Vec::new());
+    let buf = std::mem::replace(&mut t.buf, empty.as_mut_ptr());
+    let capacity = std::mem::replace(&mut t.capacity, 0);
+    let actual_len = std::mem::replace(&mut t.actual_len, 0);
+    unsafe { Vec::from_raw_parts(buf, actual_len as usize, capacity as usize) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transfer::internal::{Idle, Notify};
+
+    /// The transfer node (`TransferInner`) holds one strong reference to its
+    /// completion `Notify`, so the Arc's strong count is a hardware-free leak
+    /// detector: after extracting the buffer the count must return to 1.
+    /// The previous `ManuallyDrop` extraction leaked the node and kept the
+    /// count at 2 — this test fails against that implementation.
+    #[test]
+    fn control_in_extraction_frees_the_transfer_inner() {
+        let notify = Arc::new(Notify::new());
+        let dyn_notify: Arc<dyn AsRef<Notify> + Send + Sync> = notify.clone();
+
+        // A "completed" 8-of-64-byte read, built exactly like control_in does.
+        // The kernel would have written the first actual_len bytes; fill them
+        // here so the Vec reconstructed by take_completed_vec never claims
+        // uninitialized memory (Vec::from_raw_parts requires len initialized).
+        let mut v = ManuallyDrop::new(Vec::<u8>::with_capacity(64));
+        unsafe { v.as_mut_ptr().write_bytes(0xAB, 8) };
+        let mut td = unsafe { TransferData::from_raw(v.as_mut_ptr(), 64, v.capacity() as u32) };
+        td.actual_len = 8;
+        let t = Idle::new(dyn_notify, td);
+        assert_eq!(
+            Arc::strong_count(&notify),
+            2,
+            "the transfer node holds one Notify ref"
+        );
+
+        let buf = take_completed_vec(t);
+
+        assert_eq!(
+            buf, [0xAB; 8],
+            "extraction returns the actual_len bytes the kernel wrote"
+        );
+        assert_eq!(
+            Arc::strong_count(&notify),
+            1,
+            "the transfer node must be freed after buffer extraction — the \
+             ManuallyDrop pattern leaks it (and one pthread mutex) on every \
+             successful control_in"
+        );
     }
 }


### PR DESCRIPTION
## The bug

`MacDevice::control_in`'s success path wraps the whole `Idle<TransferData>` in `ManuallyDrop` to steal the buffer pointer for `Vec::from_raw_parts`:

```rust
let t = ManuallyDrop::new(t);
Ok(unsafe { Vec::from_raw_parts(t.buf, t.actual_len as usize, t.capacity as usize) })
```

Suppressing the drop of the entire transfer handle means the boxed `TransferInner` — and the pthread mutex inside its completion `Notify` — is leaked on **every successful `control_in`**. The error path and `control_out` drop the transfer normally and don't leak.

## How it was found

A long-running app that polls a modem-status register via `control_in` at 20 Hz grew steadily (~11 MB/hour; a 16.5-hour run went from 158 MB to 337 MB RSS with 1.18M leaked pthread mutexes). `leaks` with `MallocStackLogging` traced every leaked block to this call site, at ~61 blocks/s.

## The fix

Extract the buffer by swapping the pointer/capacity/length fields out of the `TransferData` — the same pattern `take_completion` already uses on the endpoint path — and let the transfer handle drop normally:

```rust
fn take_completed_vec(mut t: Idle<TransferData>) -> Vec<u8> {
    let mut empty = ManuallyDrop::new(Vec::new());
    let buf = std::mem::replace(&mut t.buf, empty.as_mut_ptr());
    let capacity = std::mem::replace(&mut t.capacity, 0);
    let actual_len = std::mem::replace(&mut t.actual_len, 0);
    unsafe { Vec::from_raw_parts(buf, actual_len as usize, capacity as usize) }
}
```

The transfer's own `Drop` then frees nothing extra (its buffer fields are an empty placeholder with capacity 0), so the buffer is freed exactly once — by the returned `Vec`.

With the fix, the same 20 Hz polling workload runs with flat RSS (verified over a soak with `leaks`: the per-call leak is gone).

## Regression test

The test builds a completed transfer the same way `control_in` does and uses `Arc::strong_count` of the completion `Notify` as a hardware-free leak detector: `TransferInner` holds one strong reference, so the count must return to 1 after the buffer is extracted. It fails against the previous `ManuallyDrop` implementation (count stays at 2) and passes with the fix. The buffer's first `actual_len` bytes are initialized (as the kernel would have) so the reconstructed `Vec` honors `Vec::from_raw_parts`'s initialization contract, and the test also asserts the extracted bytes round-trip.

Tested on macOS: `cargo test` with default features and the `tokio`/`smol`/`smol,tokio` combos, plus `cargo fmt --check`.