### PR TITLE
macos: Support kernel driver detach and attach

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ windows-sys = { version = ">= 0.60, <= 0.61", features = ["Win32_Devices_Usb", "
 core-foundation = "0.10.1"
 core-foundation-sys = "0.8.4"
 io-kit-sys = "0.5.0"
+libc = "0.2"
 
 [target.'cfg(any(target_os="linux", target_os="android", target_os="windows", target_os="macos"))'.dependencies]
 blocking = { version = "1.6.1", optional = true }

--- a/examples/detach.rs
+++ b/examples/detach.rs
@@ -1,4 +1,6 @@
 //! Detach the kernel driver for an FTDI device and then reattach it.
+//!
+//! On macOS, detaching captures the whole device and attaching releases the whole device.
 use std::{thread::sleep, time::Duration};
 
 use nusb::MaybeFuture;

--- a/src/device.rs
+++ b/src/device.rs
@@ -98,8 +98,8 @@ impl Device {
     /// Detach kernel drivers and open an interface of the device and claim it for exclusive use.
     ///
     /// ### Platform-specific details
-    /// This function can only detach kernel drivers on Linux. Calling on other platforms has
-    /// the same effect as [`claim_interface`][`Device::claim_interface`].
+    /// Linux detaches the driver then claims. macOS opens the interface with seize (evicts a
+    /// matched kernel driver). Windows has no effect beyond [`claim_interface`][`Device::claim_interface`].
     pub fn detach_and_claim_interface(
         &self,
         interface: u8,
@@ -113,10 +113,13 @@ impl Device {
     /// Detach kernel drivers for the specified interface.
     ///
     /// ### Platform-specific details
-    /// This function can only detach kernel drivers on Linux. Calling on other platforms has
-    /// no effect.
+    /// Linux detaches the given interface's driver. macOS captures the whole device, terminating
+    /// its non-mass-storage kernel drivers; this requires root or the
+    /// `com.apple.vm.device-access` entitlement. macOS returns [`ErrorKind::Busy`] while any
+    /// interface is claimed and [`ErrorKind::Unsupported`] for a mass-storage interface. No effect
+    /// on other platforms.
     pub fn detach_kernel_driver(&self, interface: u8) -> Result<(), Error> {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         self.backend.detach_kernel_driver(interface)?;
         let _ = interface;
 
@@ -126,10 +129,12 @@ impl Device {
     /// Attach kernel drivers for the specified interface.
     ///
     /// ### Platform-specific details
-    /// This function can only attach kernel drivers on Linux. Calling on other platforms has
-    /// no effect.
+    /// Linux attaches the driver for the given interface. On macOS, any interface number releases
+    /// the whole previously-captured device back to the operating system; it returns
+    /// [`ErrorKind::Busy`] if an interface remains claimed or the device was not captured. No
+    /// effect on other platforms.
     pub fn attach_kernel_driver(&self, interface: u8) -> Result<(), Error> {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         self.backend.attach_kernel_driver(interface)?;
         let _ = interface;
 

--- a/src/platform/macos_iokit/device.rs
+++ b/src/platform/macos_iokit/device.rs
@@ -3,13 +3,17 @@ use std::{
     ffi::c_void,
     sync::{
         atomic::{AtomicU8, AtomicUsize, Ordering},
-        Arc, Mutex,
+        Arc, Mutex, MutexGuard,
     },
     task::{Context, Poll},
     time::Duration,
 };
 
-use io_kit_sys::ret::{kIOReturnSuccess, IOReturn};
+use io_kit_sys::ret::{
+    kIOReturnBadArgument, kIOReturnBusy, kIOReturnExclusiveAccess, kIOReturnNoDevice,
+    kIOReturnNotFound, kIOReturnNotOpen, kIOReturnNotPermitted, kIOReturnNotPrivileged,
+    kIOReturnSuccess, kIOReturnUnsupported, IOReturn,
+};
 use log::{debug, error};
 
 use crate::{
@@ -28,20 +32,70 @@ use crate::{
 use super::{
     enumeration::{device_descriptor_from_fields, get_integer_property, service_by_registry_id},
     events::{add_event_source, EventRegistration},
-    iokit::call_iokit_function,
+    iokit::{call_iokit_function, IoService},
     iokit_c::IOUSBDevRequestTO,
     iokit_usb::{IoKitDevice, IoKitInterface},
     TransferData,
 };
 
-pub(crate) struct MacDevice {
+pub(super) struct DeviceConnection {
     _event_registration: EventRegistration,
-    pub(super) device: IoKitDevice,
+    device: IoKitDevice,
+    is_open_exclusive: Mutex<bool>,
+}
+
+impl DeviceConnection {
+    fn new(service: &IoService) -> Result<Arc<Self>, Error> {
+        let device = IoKitDevice::new(service)?;
+        let event_source = device
+            .create_async_event_source()
+            .map_err(|e| iokit_error(e, "failed to create async event source").log_error())?;
+
+        Ok(Arc::new(Self {
+            _event_registration: add_event_source(event_source),
+            device,
+            is_open_exclusive: Mutex::new(false),
+        }))
+    }
+
+    fn open(&self) -> Result<(), IOReturn> {
+        let mut is_open_exclusive = self.is_open_exclusive.lock().unwrap();
+        if !*is_open_exclusive {
+            self.device.open()?;
+            *is_open_exclusive = true;
+        }
+        Ok(())
+    }
+
+    fn mark_closed(&self) {
+        *self.is_open_exclusive.lock().unwrap() = false;
+    }
+}
+
+impl Drop for DeviceConnection {
+    fn drop(&mut self) {
+        if *self.is_open_exclusive.get_mut().unwrap() {
+            if let Err(err) = self.device.close() {
+                // Expected after capture/release or disconnection, when IOKit has already closed
+                // the user client.
+                log::debug!("Failed to close device: {err:x}");
+            }
+        }
+    }
+}
+
+struct DeviceState {
+    connection: Arc<DeviceConnection>,
+    captured: bool,
+}
+
+pub(crate) struct MacDevice {
+    registry_id: u64,
+    state: Mutex<DeviceState>,
     device_descriptor: DeviceDescriptor,
     config_descriptors: Vec<Vec<u8>>,
     speed: Option<Speed>,
     active_config: AtomicU8,
-    is_open_exclusive: Mutex<bool>,
     claimed_interfaces: AtomicUsize,
 }
 
@@ -57,6 +111,53 @@ fn guess_active_config(configs: &[Vec<u8>], dev: &IoKitDevice) -> Option<u8> {
     configs[0].get(5).copied() // get bConfigurationValue from descriptor
 }
 
+fn validate_capture_interface(
+    configs: &[Vec<u8>],
+    active_config: u8,
+    interface: u8,
+) -> Result<(), Error> {
+    let config = configs
+        .iter()
+        .map(|d| ConfigurationDescriptor::new_unchecked(d))
+        .find(|d| d.configuration_value() == active_config)
+        .ok_or_else(|| Error::new(ErrorKind::NotFound, "active configuration not found"))?;
+
+    let mut alt_settings = config
+        .interface_alt_settings()
+        .filter(|d| d.interface_number() == interface)
+        .peekable();
+
+    if alt_settings.peek().is_none() {
+        return Err(Error::new(ErrorKind::NotFound, "interface not found"));
+    }
+
+    // Apple deliberately leaves mass-storage interface drivers attached during device capture.
+    // Reject any interface that has a mass-storage alternate setting rather than reporting a
+    // successful detach that did not actually make the interface claimable.
+    if alt_settings.any(|d| d.class() == 0x08) {
+        return Err(Error::new(
+            ErrorKind::Unsupported,
+            "macOS cannot detach mass-storage interface drivers",
+        ));
+    }
+
+    Ok(())
+}
+
+#[allow(non_upper_case_globals)]
+fn iokit_error(code: IOReturn, message: &'static str) -> Error {
+    let kind = match code {
+        kIOReturnNoDevice | kIOReturnNotOpen => ErrorKind::Disconnected,
+        kIOReturnBusy | kIOReturnExclusiveAccess => ErrorKind::Busy,
+        kIOReturnNotPermitted | kIOReturnNotPrivileged => ErrorKind::PermissionDenied,
+        kIOReturnNotFound => ErrorKind::NotFound,
+        kIOReturnUnsupported => ErrorKind::Unsupported,
+        _ => ErrorKind::Other,
+    };
+
+    Error::new_os(kind, message, code)
+}
+
 impl MacDevice {
     pub(crate) fn from_device_info(
         d: &DeviceInfo,
@@ -66,19 +167,11 @@ impl MacDevice {
         Blocking::new(move || {
             log::info!("Opening device from registry id {}", registry_id);
             let service = service_by_registry_id(registry_id)?;
-            let device = IoKitDevice::new(&service)?;
-            let event_source = device.create_async_event_source().map_err(|e| {
-                Error::new_os(ErrorKind::Other, "failed to create async event source", e)
-                    .log_error()
-            })?;
-            let _event_registration = add_event_source(event_source);
+            let connection = DeviceConnection::new(&service)?;
 
-            let opened = device
-                .open()
-                .inspect_err(|err| {
-                    log::debug!("Could not open device for exclusive access: 0x{err:08x}");
-                })
-                .is_ok();
+            if let Err(err) = connection.open() {
+                log::debug!("Could not open device for exclusive access: 0x{err:08x}");
+            }
 
             let device_descriptor = device_descriptor_from_fields(&service).ok_or_else(|| {
                 Error::new(
@@ -87,17 +180,15 @@ impl MacDevice {
                 )
             })?;
 
-            let num_configs = device.get_number_of_configurations().map_err(|e| {
-                Error::new_os(
-                    ErrorKind::Other,
-                    "failed to get number of configurations",
-                    e,
-                )
-            })?;
+            let num_configs = connection
+                .device
+                .get_number_of_configurations()
+                .map_err(|e| iokit_error(e, "failed to get number of configurations"))?;
 
             let config_descriptors: Vec<Vec<u8>> = (0..num_configs)
                 .flat_map(|i| {
-                    let d = device
+                    let d = connection
+                        .device
                         .get_configuration_descriptor(i)
                         .inspect_err(|e| {
                             log::warn!("failed to get configuration descriptor {i}: {e}");
@@ -109,24 +200,27 @@ impl MacDevice {
                 .map(|desc| desc.to_owned())
                 .collect();
 
-            let active_config =
-                if let Some(active_config) = guess_active_config(&config_descriptors, &device) {
-                    log::debug!("Active config from single descriptor is {}", active_config);
-                    active_config
-                } else {
-                    let res = device.get_configuration();
-                    log::debug!("Active config from request is {:?}", res);
-                    res.unwrap_or(0)
-                };
+            let active_config = if let Some(active_config) =
+                guess_active_config(&config_descriptors, &connection.device)
+            {
+                log::debug!("Active config from single descriptor is {}", active_config);
+                active_config
+            } else {
+                let res = connection.device.get_configuration();
+                log::debug!("Active config from request is {:?}", res);
+                res.unwrap_or(0)
+            };
 
             Ok(Arc::new(MacDevice {
-                _event_registration,
-                device,
+                registry_id,
+                state: Mutex::new(DeviceState {
+                    connection,
+                    captured: false,
+                }),
                 device_descriptor,
                 config_descriptors,
                 speed,
                 active_config: AtomicU8::new(active_config),
-                is_open_exclusive: Mutex::new(opened),
                 claimed_interfaces: AtomicUsize::new(0),
             }))
         })
@@ -152,30 +246,126 @@ impl MacDevice {
             .map(|d| ConfigurationDescriptor::new_unchecked(&d[..]))
     }
 
-    fn require_open_exclusive(&self) -> Result<(), Error> {
-        let mut is_open_exclusive = self.is_open_exclusive.lock().unwrap();
-        if !*is_open_exclusive {
-            self.device.open().map_err(|e| match e {
-                io_kit_sys::ret::kIOReturnNoDevice => {
-                    Error::new_os(ErrorKind::Disconnected, "device disconnected", e)
-                }
-                _ => Error::new_os(
-                    ErrorKind::Other,
-                    "could not open device for exclusive access",
-                    e,
-                ),
-            })?;
-            *is_open_exclusive = true;
+    /// Capture the device (device-wide): terminate its non-mass-storage kernel drivers so an
+    /// interface claim can succeed. Needs root or the `com.apple.vm.device-access` entitlement.
+    pub(crate) fn detach_kernel_driver(&self, interface: u8) -> Result<(), Error> {
+        let mut state = self.state.lock().unwrap();
+
+        validate_capture_interface(
+            &self.config_descriptors,
+            self.active_config.load(Ordering::SeqCst),
+            interface,
+        )?;
+
+        if self.claimed_interfaces.load(Ordering::Acquire) != 0 {
+            return Err(Error::new(
+                ErrorKind::Busy,
+                "cannot capture device while interfaces are claimed",
+            ));
         }
 
-        if self.claimed_interfaces.load(Ordering::Relaxed) != 0 {
+        // Capture is device-wide, so repeated detach requests do not need another disruptive
+        // re-enumeration.
+        if state.captured {
+            return Ok(());
+        }
+
+        let service = service_by_registry_id(self.registry_id)?;
+        if unsafe { libc::geteuid() } != 0 {
+            service.authorize().map_err(|e| {
+                iokit_error(
+                    e,
+                    "failed to authorize USB device; capture requires root or the com.apple.vm.device-access entitlement",
+                )
+            })?;
+        }
+
+        // Authorization is cached when the user client starts, so build a fresh user client after
+        // IOServiceAuthorize. Creating its event source before capture also keeps callbacks valid
+        // through the close-and-reopen performed by capture.
+        let new_connection = DeviceConnection::new(&service)?;
+        new_connection
+            .device
+            .reenumerate_capture()
+            .map_err(|e| iokit_error(e, "failed to capture USB device"))?;
+
+        match new_connection.open() {
+            Ok(()) => {
+                state.connection = new_connection;
+                state.captured = true;
+                Ok(())
+            }
+            Err(open_error) => {
+                // The capture itself succeeded, so update the active connection even when the
+                // reopen fails. If rollback also fails, preserve the captured state so a later
+                // attach_kernel_driver call can retry the release.
+                match new_connection.device.reenumerate_release() {
+                    Ok(()) => {
+                        new_connection.mark_closed();
+                        state.connection = new_connection;
+                        state.captured = false;
+                        Err(iokit_error(
+                            open_error,
+                            "failed to reopen USB device after capture",
+                        ))
+                    }
+                    Err(release_error) => {
+                        log::error!(
+                            "Failed to reopen captured device: 0x{open_error:08x}; rollback also failed: 0x{release_error:08x}"
+                        );
+                        state.connection = new_connection;
+                        state.captured = true;
+                        Err(iokit_error(
+                            release_error,
+                            "failed to release USB device after capture setup failed",
+                        ))
+                    }
+                }
+            }
+        }
+    }
+
+    /// Release the device-wide capture. The interface number is intentionally ignored on macOS.
+    pub(crate) fn attach_kernel_driver(&self, _interface: u8) -> Result<(), Error> {
+        let mut state = self.state.lock().unwrap();
+
+        if self.claimed_interfaces.load(Ordering::Acquire) != 0 {
+            return Err(Error::new(
+                ErrorKind::Busy,
+                "cannot release captured device while interfaces are claimed",
+            ));
+        }
+
+        if !state.captured {
+            return Err(Error::new(ErrorKind::Busy, "USB device is not captured"));
+        }
+
+        state
+            .connection
+            .device
+            .reenumerate_release()
+            .map_err(|e| iokit_error(e, "failed to release captured USB device"))?;
+        state.connection.mark_closed();
+        state.captured = false;
+        Ok(())
+    }
+
+    fn require_open_exclusive(&self) -> Result<MutexGuard<'_, DeviceState>, Error> {
+        let state = self.state.lock().unwrap();
+
+        if self.claimed_interfaces.load(Ordering::Acquire) != 0 {
             return Err(Error::new(
                 ErrorKind::Busy,
                 "cannot perform this operation while interfaces are claimed",
             ));
         }
 
-        Ok(())
+        state
+            .connection
+            .open()
+            .map_err(|e| iokit_error(e, "could not open device for exclusive access"))?;
+
+        Ok(state)
     }
 
     pub(crate) fn set_configuration(
@@ -183,18 +373,12 @@ impl MacDevice {
         configuration: u8,
     ) -> impl MaybeFuture<Output = Result<(), Error>> {
         Blocking::new(move || {
-            self.require_open_exclusive()?;
-            self.device
+            let state = self.require_open_exclusive()?;
+            state
+                .connection
+                .device
                 .set_configuration(configuration)
-                .map_err(|e| match e {
-                    io_kit_sys::ret::kIOReturnNoDevice => {
-                        Error::new_os(ErrorKind::Disconnected, "device disconnected", e)
-                    }
-                    io_kit_sys::ret::kIOReturnNotFound => {
-                        Error::new_os(ErrorKind::NotFound, "configuration not found", e)
-                    }
-                    _ => Error::new_os(ErrorKind::Other, "failed to set configuration", e),
-                })?;
+                .map_err(|e| iokit_error(e, "failed to set configuration"))?;
             log::debug!("Set configuration {configuration}");
             self.active_config.store(configuration, Ordering::SeqCst);
             Ok(())
@@ -203,13 +387,12 @@ impl MacDevice {
 
     pub(crate) fn reset(self: Arc<Self>) -> impl MaybeFuture<Output = Result<(), Error>> {
         Blocking::new(move || {
-            self.require_open_exclusive()?;
-            self.device.reset().map_err(|e| match e {
-                io_kit_sys::ret::kIOReturnNoDevice => {
-                    Error::new_os(ErrorKind::Disconnected, "device disconnected", e)
-                }
-                _ => Error::new_os(ErrorKind::Other, "failed to reset device", e),
-            })
+            let state = self.require_open_exclusive()?;
+            state
+                .connection
+                .device
+                .reset()
+                .map_err(|e| iokit_error(e, "failed to reset device"))
         })
     }
 
@@ -217,13 +400,24 @@ impl MacDevice {
         self: Arc<Self>,
         interface_number: u8,
     ) -> impl MaybeFuture<Output = Result<Arc<MacInterface>, Error>> {
+        self.claim_interface_inner(interface_number, false)
+    }
+
+    /// Claim an interface, `seize`ing it from a kernel driver if set.
+    fn claim_interface_inner(
+        self: Arc<Self>,
+        interface_number: u8,
+        seize: bool,
+    ) -> impl MaybeFuture<Output = Result<Arc<MacInterface>, Error>> {
         Blocking::new(move || {
-            let intf_service = self
+            // Holding the device state lock through the successful open and claim count update
+            // prevents capture/release from racing the creation of a live interface.
+            let state = self.state.lock().unwrap();
+            let intf_service = state
+                .connection
                 .device
                 .create_interface_iterator()
-                .map_err(|e| {
-                    Error::new_os(ErrorKind::Other, "failed to create interface iterator", e)
-                })?
+                .map_err(|e| iokit_error(e, "failed to create interface iterator"))?
                 .find(|io_service| {
                     get_integer_property(io_service, "bInterfaceNumber")
                         == Some(interface_number as i64)
@@ -231,24 +425,19 @@ impl MacDevice {
                 .ok_or(Error::new(ErrorKind::NotFound, "interface not found"))?;
 
             let mut interface = IoKitInterface::new(intf_service)?;
-            let source = interface.create_async_event_source().map_err(|e| {
-                Error::new_os(ErrorKind::Other, "failed to create async event source", e)
-                    .log_error()
-            })?;
+            let source = interface
+                .create_async_event_source()
+                .map_err(|e| iokit_error(e, "failed to create async event source").log_error())?;
             let _event_registration = add_event_source(source);
 
-            interface.open().map_err(|e| match e {
-                io_kit_sys::ret::kIOReturnExclusiveAccess => Error::new_os(
-                    ErrorKind::Busy,
-                    "could not open interface for exclusive access",
-                    e,
-                ),
-                io_kit_sys::ret::kIOReturnNoDevice => {
-                    Error::new_os(ErrorKind::Disconnected, "device disconnected", e)
-                }
-                _ => Error::new_os(ErrorKind::Other, "failed to open interface", e),
-            })?;
-            self.claimed_interfaces.fetch_add(1, Ordering::Acquire);
+            let opened = if seize {
+                interface.open_seize()
+            } else {
+                interface.open()
+            };
+            opened.map_err(|e| iokit_error(e, "failed to open interface"))?;
+            self.claimed_interfaces.fetch_add(1, Ordering::Release);
+            drop(state);
 
             Ok(Arc::new(MacInterface {
                 device: self.clone(),
@@ -264,7 +453,7 @@ impl MacDevice {
         self: Arc<Self>,
         interface: u8,
     ) -> impl MaybeFuture<Output = Result<Arc<MacInterface>, Error>> {
-        self.claim_interface(interface)
+        self.claim_interface_inner(interface, true)
     }
 
     pub fn control_in(
@@ -274,7 +463,10 @@ impl MacDevice {
     ) -> impl MaybeFuture<Output = Result<Vec<u8>, TransferError>> {
         let timeout = timeout.as_millis().try_into().expect("timeout too long");
 
+        let state = self.state.lock().unwrap();
+        let connection = state.connection.clone();
         let mut t = TransferData::new();
+        t.pin_device_connection(connection.clone());
         t.put_buffer(Buffer::new(data.length as usize), Direction::In);
 
         let req = IOUSBDevRequestTO {
@@ -289,8 +481,12 @@ impl MacDevice {
             noDataTimeout: timeout,
         };
 
-        TransferFuture::new(t, |t| self.submit_control(Direction::In, t, req)).map(move |mut t| {
-            drop(self); // ensure device stays alive
+        let transfer = TransferFuture::new(t, move |t| {
+            Self::submit_control(&connection, Direction::In, t, req)
+        });
+        drop(state);
+
+        transfer.map(move |mut t| {
             let c = unsafe { t.take_completion(Direction::In) };
             c.status?;
             Ok(c.buffer.into_vec())
@@ -304,7 +500,10 @@ impl MacDevice {
     ) -> impl MaybeFuture<Output = Result<(), TransferError>> {
         let timeout = timeout.as_millis().try_into().expect("timeout too long");
 
+        let state = self.state.lock().unwrap();
+        let connection = state.connection.clone();
         let mut t = TransferData::new();
+        t.pin_device_connection(connection.clone());
         t.put_buffer(Buffer::from(data.data), Direction::Out);
 
         let req = IOUSBDevRequestTO {
@@ -319,15 +518,19 @@ impl MacDevice {
             noDataTimeout: timeout,
         };
 
-        TransferFuture::new(t, |t| self.submit_control(Direction::Out, t, req)).map(move |mut t| {
-            drop(self); // ensure device stays alive
+        let transfer = TransferFuture::new(t, move |t| {
+            Self::submit_control(&connection, Direction::Out, t, req)
+        });
+        drop(state);
+
+        transfer.map(move |mut t| {
             let c = unsafe { t.take_completion(Direction::Out) };
             c.status
         })
     }
 
     fn submit_control(
-        &self,
+        connection: &DeviceConnection,
         dir: Direction,
         mut t: Idle<TransferData>,
         mut req: IOUSBDevRequestTO,
@@ -340,7 +543,7 @@ impl MacDevice {
 
         let res = unsafe {
             call_iokit_function!(
-                self.device.raw,
+                connection.device.raw,
                 DeviceRequestAsyncTO(&mut req, Some(transfer_callback), ptr as *mut c_void)
             )
         };
@@ -357,17 +560,6 @@ impl MacDevice {
         }
 
         t
-    }
-}
-
-impl Drop for MacDevice {
-    fn drop(&mut self) {
-        if *self.is_open_exclusive.get_mut().unwrap() {
-            match unsafe { call_iokit_function!(self.device.raw, USBDeviceClose()) } {
-                io_kit_sys::ret::kIOReturnSuccess => {}
-                err => log::debug!("Failed to close device: {err:x}"),
-            };
-        }
     }
 }
 
@@ -402,12 +594,7 @@ impl MacInterface {
 
             self.interface
                 .set_alternate_interface(alt_setting)
-                .map_err(|e| match e {
-                    io_kit_sys::ret::kIOReturnNoDevice => {
-                        Error::new_os(ErrorKind::Disconnected, "device disconnected", e)
-                    }
-                    _ => Error::new_os(ErrorKind::Other, "failed to set alternate interface", e),
-                })?;
+                .map_err(|e| iokit_error(e, "failed to set alternate interface"))?;
 
             debug!(
                 "Set interface {} alt setting to {alt_setting}",
@@ -603,7 +790,7 @@ impl MacEndpoint {
     pub(crate) fn submit_err(&mut self, buffer: Buffer, err: TransferError) {
         assert_eq!(err, TransferError::InvalidArgument);
         let mut transfer = self.make_transfer(buffer);
-        transfer.status = io_kit_sys::ret::kIOReturnBadArgument;
+        transfer.status = kIOReturnBadArgument;
         self.pending.push_back(transfer.simulate_complete());
     }
 
@@ -639,12 +826,7 @@ impl MacEndpoint {
                 .interface
                 .interface
                 .clear_pipe_stall_both_ends(inner.pipe_ref)
-                .map_err(|e| match e {
-                    io_kit_sys::ret::kIOReturnNoDevice => {
-                        Error::new_os(ErrorKind::Disconnected, "device disconnected", e)
-                    }
-                    _ => Error::new_os(ErrorKind::Other, "failed to clear halt on endpoint", e),
-                })
+                .map_err(|e| iokit_error(e, "failed to clear halt on endpoint"))
         })
     }
 }
@@ -684,5 +866,58 @@ extern "C" fn transfer_callback(refcon: *mut c_void, result: IOReturn, len: *mut
         (*transfer).actual_len = len;
         (*transfer).status = result;
         notify_completion::<TransferData>(transfer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn configuration(value: u8, num_interfaces: u8, settings: &[(u8, u8, u8)]) -> Vec<u8> {
+        let total_length = 9 + settings.len() * 9;
+        let mut descriptor = vec![
+            9,
+            2,
+            total_length as u8,
+            (total_length >> 8) as u8,
+            num_interfaces,
+            value,
+            0,
+            0x80,
+            50,
+        ];
+        for &(interface, alternate_setting, class) in settings {
+            descriptor.extend_from_slice(&[9, 4, interface, alternate_setting, 0, class, 0, 0, 0]);
+        }
+        descriptor
+    }
+
+    #[test]
+    fn test_capture_validation_uses_only_the_active_configuration() {
+        let configs = vec![
+            configuration(1, 1, &[(1, 0, 0xff)]),
+            configuration(2, 1, &[(2, 0, 0xff)]),
+        ];
+
+        assert!(validate_capture_interface(&configs, 2, 2).is_ok());
+
+        let inactive_interface = validate_capture_interface(&configs, 2, 1).unwrap_err();
+        assert_eq!(
+            inactive_interface.kind(),
+            ErrorKind::NotFound,
+            "an interface that exists only in an inactive configuration must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_capture_rejects_mass_storage_in_any_alternate_setting() {
+        let configs = vec![configuration(1, 1, &[(3, 0, 0xff), (3, 1, 0x08)])];
+
+        let mass_storage = validate_capture_interface(&configs, 1, 3).unwrap_err();
+        assert_eq!(
+            mass_storage.kind(),
+            ErrorKind::Unsupported,
+            "Apple leaves mass-storage drivers attached during device capture"
+        );
     }
 }

--- a/src/platform/macos_iokit/iokit.rs
+++ b/src/platform/macos_iokit/iokit.rs
@@ -4,7 +4,10 @@
 //! licensed under MIT OR Apache-2.0.
 
 use core_foundation_sys::uuid::CFUUIDBytes;
-use io_kit_sys::{ret::IOReturn, IOIteratorNext, IOObjectRelease};
+use io_kit_sys::ret::{kIOReturnSuccess, IOReturn};
+use io_kit_sys::{
+    kIOServiceInteractionAllowed, IOIteratorNext, IOObjectRelease, IOServiceAuthorize,
+};
 
 use super::iokit_c::{self, CFUUIDGetUUIDBytes, IOCFPlugInInterface};
 
@@ -37,6 +40,11 @@ impl IoService {
     }
     pub fn get(&self) -> u32 {
         self.0 .0
+    }
+
+    /// Ask IOKit to authorize this process to open the service.
+    pub(crate) fn authorize(&self) -> Result<(), IOReturn> {
+        unsafe { check_iokit_return(IOServiceAuthorize(self.get(), kIOServiceInteractionAllowed)) }
     }
 }
 
@@ -112,9 +120,10 @@ pub(crate) fn usb_interface_type_id() -> CFUUIDBytes {
     unsafe { CFUUIDGetUUIDBytes(iokit_c::kIOUSBInterfaceInterfaceID700()) }
 }
 
+#[allow(non_upper_case_globals)]
 pub(crate) fn check_iokit_return(r: IOReturn) -> Result<(), IOReturn> {
     match r {
-        io_kit_sys::ret::kIOReturnSuccess => Ok(()),
+        kIOReturnSuccess => Ok(()),
         e => Err(e),
     }
 }

--- a/src/platform/macos_iokit/iokit_usb.rs
+++ b/src/platform/macos_iokit/iokit_usb.rs
@@ -121,6 +121,10 @@ impl IoKitDevice {
         unsafe { check_iokit_return(call_iokit_function!(self.raw, USBDeviceOpen())) }
     }
 
+    pub(crate) fn close(&self) -> Result<(), IOReturn> {
+        unsafe { check_iokit_return(call_iokit_function!(self.raw, USBDeviceClose())) }
+    }
+
     pub(crate) fn set_configuration(&self, configuration: u8) -> Result<(), IOReturn> {
         unsafe {
             check_iokit_return(call_iokit_function!(
@@ -132,6 +136,29 @@ impl IoKitDevice {
 
     pub(crate) fn reset(&self) -> Result<(), IOReturn> {
         unsafe { check_iokit_return(call_iokit_function!(self.raw, USBDeviceReEnumerate(0))) }
+    }
+
+    /// Re-enumerate with `kUSBReEnumerateCaptureDeviceMask`: terminate every kernel driver on the
+    /// device and its interfaces so a claim can succeed. Needs root or an entitlement; re-open after.
+    pub(crate) fn reenumerate_capture(&self) -> Result<(), IOReturn> {
+        const CAPTURE_MASK: u32 = 1 << 30;
+        unsafe {
+            check_iokit_return(call_iokit_function!(
+                self.raw,
+                USBDeviceReEnumerate(CAPTURE_MASK)
+            ))
+        }
+    }
+
+    /// Release a device captured with `reenumerate_capture` back to the operating system.
+    pub(crate) fn reenumerate_release(&self) -> Result<(), IOReturn> {
+        const RELEASE_MASK: u32 = 1 << 29;
+        unsafe {
+            check_iokit_return(call_iokit_function!(
+                self.raw,
+                USBDeviceReEnumerate(RELEASE_MASK)
+            ))
+        }
     }
 
     pub(crate) fn create_async_event_source(&self) -> Result<CFRunLoopSource, IOReturn> {
@@ -266,6 +293,11 @@ impl IoKitInterface {
 
     pub(crate) fn open(&mut self) -> Result<(), IOReturn> {
         unsafe { check_iokit_return(call_iokit_function!(self.raw, USBInterfaceOpen())) }
+    }
+
+    /// Open the interface with seize, forcing a kernel driver holding it to close.
+    pub(crate) fn open_seize(&mut self) -> Result<(), IOReturn> {
+        unsafe { check_iokit_return(call_iokit_function!(self.raw, USBInterfaceOpenSeize())) }
     }
 
     pub(crate) fn close(&mut self) -> Result<(), IOReturn> {

--- a/src/platform/macos_iokit/transfer.rs
+++ b/src/platform/macos_iokit/transfer.rs
@@ -1,8 +1,13 @@
-use std::mem::{self, ManuallyDrop};
+use std::{
+    mem::{self, ManuallyDrop},
+    sync::Arc,
+};
 
 use io_kit_sys::ret::{kIOReturnSuccess, IOReturn};
 
 use crate::transfer::{Allocator, Buffer, Completion, Direction};
+
+use super::device::DeviceConnection;
 
 pub struct TransferData {
     pub(super) buf: *mut u8,
@@ -10,6 +15,9 @@ pub struct TransferData {
     pub(super) requested_len: u32,
     pub(super) actual_len: u32,
     pub(super) status: IOReturn,
+    /// Keeps the IOKit user client and its event source alive until a device transfer callback
+    /// has completed, even if the device refreshes its active connection in the meantime.
+    _device_connection: Option<Arc<DeviceConnection>>,
 }
 
 impl Drop for TransferData {
@@ -27,7 +35,13 @@ impl TransferData {
             requested_len: 0,
             actual_len: 0,
             status: kIOReturnSuccess,
+            _device_connection: None,
         }
+    }
+
+    pub(super) fn pin_device_connection(&mut self, connection: Arc<DeviceConnection>) {
+        debug_assert!(self._device_connection.is_none());
+        self._device_connection = Some(connection);
     }
 
     pub fn put_buffer(&mut self, buffer: Buffer, direction: Direction) {


### PR DESCRIPTION
- Seize interfaces for detach-and-claim.
- Capture and release devices for explicit detach and attach.
- Authorize capture, reject unsafe states, and retain connections for pending transfers.

Tested with `cargo test --all-features`.