### PR TITLE
Add Interface::release()

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -554,6 +554,19 @@ impl Interface {
             ep_dir: PhantomData,
         })
     }
+
+    /// Release the interface.
+    ///
+    /// Returns an error (`ErrorKind::Busy`) if any other reference to this
+    /// `Interface` still exists, including those from `Endpoint`s or their
+    /// pending transfers. Errors from disconnected devices are silently
+    /// ignored.
+    ///
+    /// This is the same as what occurs on `Drop` of the last clone of the
+    /// `Interface`, but allows it to be called asynchronously.
+    pub fn release(self) -> impl MaybeFuture<Output = Result<(), Error>> {
+        self.backend.release()
+    }
 }
 
 impl Debug for Interface {

--- a/src/platform/linux_usbfs/device.rs
+++ b/src/platform/linux_usbfs/device.rs
@@ -719,6 +719,18 @@ impl LinuxInterface {
             idle_transfer: None,
         })
     }
+
+    pub fn release(self: Arc<Self>) -> impl MaybeFuture<Output = Result<(), Error>> {
+        Blocking::new(move || {
+            if let Some(this) = Arc::into_inner(self) {
+                // USBDEVFS_RELEASEINTERFACE only fails on invalid argument, so no need to get a result out of drop.
+                drop(this);
+                Ok(())
+            } else {
+                return Err(Error::new(ErrorKind::Busy, "interface is still in use"));
+            }
+        })
+    }
 }
 
 impl Drop for LinuxInterface {

--- a/src/platform/macos_iokit/device.rs
+++ b/src/platform/macos_iokit/device.rs
@@ -474,6 +474,19 @@ impl MacInterface {
             idle_transfer: None,
         })
     }
+
+    pub fn release(self: Arc<Self>) -> impl MaybeFuture<Output = Result<(), Error>> {
+        Blocking::new(move || {
+            if let Some(this) = Arc::into_inner(self) {
+                // USBInterfaceClose only fails on disconnected devices, but we'll ignore
+                // those errors to match the behavior of other platforms.
+                drop(this);
+                Ok(())
+            } else {
+                return Err(Error::new(ErrorKind::Busy, "interface is still in use"));
+            }
+        })
+    }
 }
 
 impl Drop for MacInterface {

--- a/src/platform/webusb/device.rs
+++ b/src/platform/webusb/device.rs
@@ -175,6 +175,7 @@ impl WebusbDevice {
                     endpoints_used: Default::default(),
                 })),
                 interface_number,
+                released: false,
                 device: self.clone(),
             }))
         })
@@ -238,12 +239,6 @@ impl WebusbDevice {
     }
 }
 
-impl Drop for WebusbInterface {
-    fn drop(&mut self) {
-        let _ = self.device.device.release_interface(self.interface_number);
-    }
-}
-
 async fn extract_descriptors(device: &UsbDevice) -> Result<Vec<Vec<u8>>, Error> {
     let num_configurations = device.configurations().length() as usize;
     let mut config_descriptors = Vec::with_capacity(num_configurations);
@@ -295,6 +290,7 @@ pub async fn get_descriptor(
 
 pub(crate) struct WebusbInterface {
     pub interface_number: u8,
+    released: bool,
     pub(crate) device: Arc<WebusbDevice>,
     state: Arc<Mutex<InterfaceState>>,
 }
@@ -380,6 +376,28 @@ impl WebusbInterface {
             max_packet_size,
             pending: VecDeque::new(),
         })
+    }
+
+    pub fn release(self: Arc<Self>) -> impl MaybeFuture<Output = Result<(), Error>> {
+        WebFuture(async move {
+            if let Some(mut this) = Arc::into_inner(self) {
+                this.released = true;
+                JsFuture::from(this.device.device.release_interface(this.interface_number))
+                    .await
+                    .map_err(js_value_to_error)?;
+                Ok(())
+            } else {
+                return Err(Error::new(ErrorKind::Busy, "interface is still in use"));
+            }
+        })
+    }
+}
+
+impl Drop for WebusbInterface {
+    fn drop(&mut self) {
+        if !self.released {
+            let _ = self.device.device.release_interface(self.interface_number);
+        }
     }
 }
 

--- a/src/platform/windows_winusb/device.rs
+++ b/src/platform/windows_winusb/device.rs
@@ -807,6 +807,18 @@ impl WindowsInterface {
             }
         }
     }
+
+    pub fn release(self: Arc<Self>) -> impl MaybeFuture<Output = Result<(), Error>> {
+        Blocking::new(move || {
+            if let Some(this) = Arc::into_inner(self) {
+                // WinUSB_Free is infallible, so just drop from the the threadpool.
+                drop(this);
+                Ok(())
+            } else {
+                return Err(Error::new(ErrorKind::Busy, "interface is still in use"));
+            }
+        })
+    }
 }
 
 pub(crate) struct WindowsEndpoint {


### PR DESCRIPTION
When the `Interface` and all its associated `Endpoint`s and transfers are dropped, we call an OS API to release the interface. On desktop platforms, this is a blocking call that may perform a `SET_INTERFACE` request to reset the alt setting, so may not be desirable to run on an executor thread. On WebUSB, where it's an async call, we have the problem that the interface is released asynchronously and may not be able to be claimed again until that is complete.

This adds a method to explicitly release the interface and async or sync wait for the underlying call to complete.