### PR TITLE
Update minimum Rust version to 1.85

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        rust: ['stable', '1.79']
+        rust: ['stable', '1.85']
 
     runs-on: ${{ matrix.os }}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Kevin Mehall <km@kevinmehall.net>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/kevinmehall/nusb"
-rust-version = "1.79" # keep in sync with .github/workflows/rust.yml
+rust-version = "1.85" # keep in sync with .github/workflows/rust.yml
 
 [dependencies]
 futures-core = "0.3.29"


### PR DESCRIPTION
* https://github.com/kevinmehall/nusb/pull/220 needs precise capture clauses (1.82)
* #199 uses LazyLock (1.80), and we're not testing wasm on the MSRV in CI
* https://github.com/kevinmehall/nusb/pull/150 depends on `jni-min-helper` which is Rust 2024 (1.85)
* Also have use cases for `&raw` (1.82) and `ErrorKind::ResourceBusy` (1.83)

Debian stable has 1.85 and that seems to be a MSRV the community is coalescing around.