### PR TITLE
Preserve WebUSB rejection details in returned errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,12 @@ tokio = { version = "1", optional = true, features = ["rt"] }
 [dev-dependencies]
 env_logger = "0.11"
 futures-lite = "2.0"
+
+[target.'cfg(not(target_arch="wasm32"))'.dev-dependencies]
 tokio = { version = "1.11", features = ["rt", "macros", "io-util", "rt-multi-thread"] }
+
+[target.'cfg(target_arch="wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"
 
 [target.'cfg(any(target_os="linux", target_os="android"))'.dependencies]
 rustix = { version = "1.0.1", features = ["fs", "event", "net", "time", "mm"] }

--- a/src/device.rs
+++ b/src/device.rs
@@ -915,6 +915,7 @@ impl<EpType: BulkOrInterrupt, Dir: EndpointDirection> Debug for Endpoint<EpType,
 }
 
 #[test]
+#[cfg(not(target_arch = "wasm32"))]
 fn assert_send_sync() {
     use crate::transfer::{Bulk, In, Interrupt, Out};
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, io, num::NonZeroU32};
+use std::{borrow::Cow, fmt::Display, io, num::NonZeroU32};
 
 use crate::{platform::format_os_error_code, transfer::TransferError};
 
@@ -7,15 +7,15 @@ use crate::{platform::format_os_error_code, transfer::TransferError};
 pub struct Error {
     pub(crate) kind: ErrorKind,
     pub(crate) code: Option<NonZeroU32>,
-    pub(crate) message: &'static str,
+    pub(crate) message: Cow<'static, str>,
 }
 
 impl Error {
-    pub(crate) fn new(kind: ErrorKind, message: &'static str) -> Self {
+    pub(crate) fn new(kind: ErrorKind, message: impl Into<Cow<'static, str>>) -> Self {
         Self {
             kind,
             code: None,
-            message,
+            message: message.into(),
         }
     }
 

--- a/src/platform/linux_usbfs/mod.rs
+++ b/src/platform/linux_usbfs/mod.rs
@@ -56,7 +56,7 @@ impl crate::error::Error {
         Self {
             kind,
             code: NonZeroU32::new(code.raw_os_error() as u32),
-            message,
+            message: message.into(),
         }
     }
 
@@ -64,7 +64,7 @@ impl crate::error::Error {
         Self {
             kind,
             code: err.raw_os_error().and_then(|i| NonZeroU32::new(i as u32)),
-            message,
+            message: message.into(),
         }
     }
 }

--- a/src/platform/macos_iokit/mod.rs
+++ b/src/platform/macos_iokit/mod.rs
@@ -50,7 +50,7 @@ impl crate::error::Error {
         Self {
             kind,
             code: NonZeroU32::new(code as u32),
-            message,
+            message: message.into(),
         }
     }
 }

--- a/src/platform/webusb/mod.rs
+++ b/src/platform/webusb/mod.rs
@@ -81,23 +81,84 @@ pub(crate) fn usb() -> Result<Usb, Error> {
     }
 }
 
+fn rejection_field(value: &JsValue, field: &str) -> Option<String> {
+    Reflect::get(value, &JsValue::from_str(field))
+        .ok()
+        .and_then(|value| value.as_string())
+        .filter(|value| !value.is_empty())
+}
+
 pub fn js_value_to_error(value: JsValue) -> Error {
-    let err: js_sys::Error = value
-        .dyn_into()
-        .unwrap_or_else(|_| js_sys::Error::new("error could not be constructed"));
-    let msg = err.message().as_string().unwrap_or_default();
-    log::warn!("WebUSB error: {msg}");
-    Error::new(ErrorKind::Other, "WebUSB error (see logs)")
+    // DOMException is not a JavaScript Error in every browser. Read the standard
+    // fields without assuming a constructor or retaining a thread-bound JsValue.
+    let name = rejection_field(&value, "name");
+    let message = rejection_field(&value, "message").or_else(|| value.as_string());
+    let detail = match (name, message) {
+        (Some(name), Some(message)) => format!("{name}: {message}"),
+        (Some(name), None) => name,
+        (None, Some(message)) => message,
+        (None, None) => format!("{value:?}"),
+    };
+    Error::new(ErrorKind::Other, format!("WebUSB error: {detail}")).log_debug()
 }
 
 pub fn js_value_to_transfer_error(value: JsValue) -> TransferError {
-    let err: js_sys::Error = value
-        .dyn_into()
-        .unwrap_or_else(|_| js_sys::Error::new("error could not be constructed"));
-    log::warn!("WebUSB transfer error: {:?}", err);
-    match err.name().as_string().as_deref() {
+    log::warn!(
+        "WebUSB transfer error: {}",
+        js_value_to_error(value.clone())
+    );
+    match rejection_field(&value, "name").as_deref() {
         Some("NetworkError") => TransferError::Disconnected,
         _ => TransferError::Fault,
+    }
+}
+
+#[cfg(test)]
+mod error_tests {
+    use super::*;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[wasm_bindgen_test]
+    fn preserves_error_dom_exception_and_string_rejections() {
+        let error = js_sys::Error::new("claim failed");
+        assert_eq!(
+            js_value_to_error(error.into()).to_string(),
+            "WebUSB error: Error: claim failed"
+        );
+        let exception =
+            js_sys::eval("new DOMException('device left while claiming', 'NetworkError')").unwrap();
+        let owned = js_value_to_error(exception.clone());
+        assert_eq!(
+            owned.to_string(),
+            "WebUSB error: NetworkError: device left while claiming"
+        );
+        assert_eq!(owned.clone().to_string(), owned.to_string());
+        assert!(matches!(
+            js_value_to_transfer_error(exception),
+            TransferError::Disconnected
+        ));
+        assert_eq!(
+            js_value_to_error(JsValue::from_str("permission denied")).to_string(),
+            "WebUSB error: permission denied"
+        );
+        fn send_sync<T: Send + Sync>() {}
+        send_sync::<Error>();
+    }
+
+    #[wasm_bindgen_test]
+    fn unusual_rejections_do_not_panic_or_erase_available_fields() {
+        let error =
+            js_sys::eval("({message:'retained', get name() {throw new Error('getter')}})").unwrap();
+        assert_eq!(
+            js_value_to_error(error).to_string(),
+            "WebUSB error: retained"
+        );
+        assert!(js_value_to_error(JsValue::NULL)
+            .to_string()
+            .starts_with("WebUSB error:"));
+        assert!(js_value_to_error(JsValue::UNDEFINED)
+            .to_string()
+            .starts_with("WebUSB error:"));
     }
 }
 

--- a/src/platform/windows_winusb/mod.rs
+++ b/src/platform/windows_winusb/mod.rs
@@ -32,7 +32,7 @@ impl crate::error::Error {
         Self {
             kind,
             code: NonZeroU32::new(code as u32),
-            message,
+            message: message.into(),
         }
     }
 }


### PR DESCRIPTION
A WebUSB promise rejection currently becomes `WebUSB error (see logs)`, hiding the browser’s actionable failure from callers. This preserves the rejection’s name and message in an owned Rust error and handles DOMException without assuming it is a JavaScript Error. DOMException NetworkError is also recognized by the existing disconnected-transfer classification.

The owned message retains Error’s Clone + Send + Sync properties. Native platform messages remain borrowed. Regression tests cover actual JavaScript Error/DOMException values, string rejections, and unusual objects whose name getter throws. The test dependencies and native endpoint Send/Sync assertion are scoped to their supported targets so the wasm tests can run.

Validation: `cargo test --lib` (11 passed); `cargo test --lib --target wasm32-unknown-unknown -- error_tests` with wasm-bindgen-test-runner 0.2.128 (2 passed in Node, no USB device involved).
